### PR TITLE
EVA-440 Removed conflicting logging dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,10 @@
                         <groupId>com.sun.jersey</groupId>
                         <artifactId>jersey-client</artifactId>
                     </exclusion>
-			        <exclusion>
-			            <groupId>javax.servlet</groupId>
-			            <artifactId>servlet-api</artifactId>
-			        </exclusion>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>com.sun.jersey.contribs</groupId>
                         <artifactId>jersey-multipart</artifactId>
@@ -81,16 +81,6 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>9.3-1102-jdbc41</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>1.7.12</version>
             </dependency>
             <dependency>
                 <groupId>asm</groupId>


### PR DESCRIPTION
Spring Boot favours Logback as logging library, that can be easily integrated with SLF4J. It was not possible to deploy the WAR file due to an extra SLF4J declaration.