### PR TITLE
EVA-471 Securing REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Build
 
 In order to build EVA, you need to install the Java Development Kit 7 and Maven.
 
-The project dependencies are OpenCGA and Variation-Commons 
+The project dependencies are OpenCGA and Variation-Commons
 
 You can get OpenCGA 0.5.2 from https://github.com/opencb/opencga, branch `hotfix/0.5`. Please follow the download/compilation instructions there.
 
@@ -28,3 +28,11 @@ The tests implemented so far are integration (not unit) tests, so a working WAR 
 3. Run `mvn jetty:run` from the eva-server subfolder
 4. Run `mvn test` from the root folder
 
+Enabling Oauth2 Security
+------------------------
+
+In order to enable Oauth2 Security you must enable the `oauth2-security` profile in the spring-boot application in any
+way supported by Spring-boot as stated in [Spring documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/howto-properties-and-configuration.html#howto-set-active-spring-profiles). In adition, the application requires configuration to point to the public user check endpoints
+of your oauth2 compatible authentication service. More information is available in [Spring documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-security.html#boot-features-security-oauth2-resource-server).
+
+When using Oauth2 Security, swagger UI will be still enabled and public to review the API but no command sent from the ui will be authorized.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,9 @@ The tests implemented so far are integration (not unit) tests, so a working WAR 
 3. Run `mvn jetty:run` from the eva-server subfolder
 4. Run `mvn test` from the root folder
 
-Enabling Oauth2 Security
+Enabling OAuth2 Security
 ------------------------
 
-In order to enable Oauth2 Security you must enable the `oauth2-security` profile in the spring-boot application in any
-way supported by Spring-boot as stated in [Spring documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/howto-properties-and-configuration.html#howto-set-active-spring-profiles). In adition, the application requires configuration to point to the public user check endpoints
-of your oauth2 compatible authentication service. More information is available in [Spring documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-security.html#boot-features-security-oauth2-resource-server).
+In order to enable OAuth2 Security you must enable the `oauth2-security` profile in the spring-boot application in any way supported by Spring-boot as stated in [Spring documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/howto-properties-and-configuration.html#howto-set-active-spring-profiles). In adition, the application requires configuration to point to the public user check endpoints of your OAuth2 compatible authentication service. More information is available in [Spring documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-security.html#boot-features-security-oauth2-resource-server).
 
-When using Oauth2 Security, swagger UI will be still enabled and public to review the API but no command sent from the ui will be authorized.
+When using OAuth2 Security, Swagger UI will be still enabled and public to review the API but no command sent from the UI will be authorized.

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -31,6 +31,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security.oauth</groupId>
+            <artifactId>spring-security-oauth2</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.springfox</groupId>

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -32,10 +32,6 @@
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
         </dependency>

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/AuthorizationConfiguration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/AuthorizationConfiguration.java
@@ -1,0 +1,20 @@
+package uk.ac.ebi.eva.server;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+
+@Configuration
+@EnableResourceServer
+public class AuthorizationConfiguration extends ResourceServerConfigurerAdapter{
+
+    public void configure(HttpSecurity http) throws Exception {
+        http.anonymous() // Enable anonymous / configure any related anonymous role
+                .and()
+                .authorizeRequests().antMatchers("/heartbeat").permitAll() //Authorize /hearbeat for everybody
+                .antMatchers("/**").authenticated() // The rest need to be authenticated
+        ;
+    }
+
+}

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/AuthorizationConfiguration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/AuthorizationConfiguration.java
@@ -12,7 +12,7 @@ public class AuthorizationConfiguration extends ResourceServerConfigurerAdapter{
     public void configure(HttpSecurity http) throws Exception {
         http.anonymous() // Enable anonymous / configure any related anonymous role
                 .and()
-                .authorizeRequests().antMatchers("/heartbeat").permitAll() //Authorize /hearbeat for everybody
+                .authorizeRequests().antMatchers("/webservices/rest/swagger-ui.html**", "/webservices/rest/swagger-resources/**","/webservices/rest/webjars/springfox-swagger-ui/**", "/webservices/rest/webservices/api").permitAll() //Authorize /hearbeat for everybody
                 .antMatchers("/**").authenticated() // The rest need to be authenticated
         ;
     }

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/Profiles.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/Profiles.java
@@ -1,0 +1,9 @@
+package uk.ac.ebi.eva.server;
+
+/**
+ * Created by jorizci on 01/11/16.
+ */
+public class Profiles {
+    public static final String OAUTH_SECURITY = "oauth2-security";
+    public static final String NOT_OAUTHSECURITY = "!"+ OAUTH_SECURITY;
+}

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/security/CORSResponseFilter.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/security/CORSResponseFilter.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package uk.ac.ebi.eva.server;
+package uk.ac.ebi.eva.server.security;
 
 import java.io.IOException;
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/security/authorization/Oauth2Configuration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/security/authorization/Oauth2Configuration.java
@@ -1,0 +1,24 @@
+package uk.ac.ebi.eva.server.security.authorization;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+
+
+@ConditionalOnProperty(prefix = "eva.server.security", name = "enabled", havingValue = "true")
+@Configuration
+@EnableResourceServer
+public class Oauth2Configuration extends ResourceServerConfigurerAdapter {
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        http.anonymous() // Enable anonymous / configure any related anonymous role
+                .and()
+                .authorizeRequests().antMatchers("/webservices/rest/swagger-ui.html**", "/webservices/rest/swagger-resources/**", "/webservices/rest/webjars/springfox-swagger-ui/**", "/webservices/rest/webservices/api").permitAll() //Authorize /hearbeat for everybody
+                .antMatchers("/**").authenticated() // The rest need to be authenticated
+        ;
+    }
+
+}

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/security/authorization/Oauth2Configuration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/security/authorization/Oauth2Configuration.java
@@ -1,14 +1,15 @@
 package uk.ac.ebi.eva.server.security.authorization;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import uk.ac.ebi.eva.server.Profiles;
 
 
-@ConditionalOnProperty(prefix = "eva.server.security", name = "enabled", havingValue = "true")
 @Configuration
+@Profile(Profiles.OAUTH_SECURITY)
 @EnableResourceServer
 public class Oauth2Configuration extends ResourceServerConfigurerAdapter {
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/security/authorization/UnsecureConfiguration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/security/authorization/UnsecureConfiguration.java
@@ -1,14 +1,15 @@
 package uk.ac.ebi.eva.server.security.authorization;
 
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import uk.ac.ebi.eva.server.Profiles;
 
-@ConditionalOnProperty(prefix = "eva.server.security", name = "enabled", matchIfMissing = true, havingValue = "false")
 @Configuration
+@Profile(Profiles.NOT_OAUTHSECURITY)
 @EnableResourceServer
 public class UnsecureConfiguration extends ResourceServerConfigurerAdapter {
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/security/authorization/UnsecureConfiguration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/security/authorization/UnsecureConfiguration.java
@@ -1,19 +1,22 @@
-package uk.ac.ebi.eva.server;
+package uk.ac.ebi.eva.server.security.authorization;
 
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
 
+@ConditionalOnProperty(prefix = "eva.server.security", name = "enabled", matchIfMissing = true, havingValue = "false")
 @Configuration
 @EnableResourceServer
-public class AuthorizationConfiguration extends ResourceServerConfigurerAdapter{
+public class UnsecureConfiguration extends ResourceServerConfigurerAdapter {
 
+    @Override
     public void configure(HttpSecurity http) throws Exception {
         http.anonymous() // Enable anonymous / configure any related anonymous role
                 .and()
-                .authorizeRequests().antMatchers("/webservices/rest/swagger-ui.html**", "/webservices/rest/swagger-resources/**","/webservices/rest/webjars/springfox-swagger-ui/**", "/webservices/rest/webservices/api").permitAll() //Authorize /hearbeat for everybody
-                .antMatchers("/**").authenticated() // The rest need to be authenticated
+                .authorizeRequests().antMatchers("/**").permitAll() //Authorize anonymous access to every mapping.
         ;
     }
 

--- a/eva-server/src/main/resources/application.properties
+++ b/eva-server/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 springfox.documentation.swagger.v2.path=/webservices/api
 
-eva.server.security.enabled = false
-#security.oauth2.resource.user-info-uri =
+#spring.profiles.active=oauth2-security
+#security.oauth2.resource.user-info-uri = ...

--- a/eva-server/src/main/resources/application.properties
+++ b/eva-server/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 springfox.documentation.swagger.v2.path=/webservices/api
 
-security.oauth2.resource.userInfoUri = http://localhost:8080/t2d-auth-0.0.1-SNAPSHOT/user
-security.oauth2.resource.user-info-uri = http://localhost:8080/t2d-auth-0.0.1-SNAPSHOT/user
+eva.server.security.enabled = false
+#security.oauth2.resource.user-info-uri =

--- a/eva-server/src/main/resources/application.properties
+++ b/eva-server/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 springfox.documentation.swagger.v2.path=/webservices/api
+
+security.oauth2.resource.userInfoUri = http://localhost:8080/t2d-auth-0.0.1-SNAPSHOT/user
+security.oauth2.resource.user-info-uri = http://localhost:8080/t2d-auth-0.0.1-SNAPSHOT/user

--- a/eva-server/src/main/webapp/WEB-INF/web.xml
+++ b/eva-server/src/main/webapp/WEB-INF/web.xml
@@ -22,7 +22,7 @@
 
     <filter>
         <filter-name>CorsFilter</filter-name>
-        <filter-class>uk.ac.ebi.eva.server.CORSResponseFilter</filter-class>
+        <filter-class>uk.ac.ebi.eva.server.security.CORSResponseFilter</filter-class>
     </filter>
     <filter-mapping>
         <filter-name>CorsFilter</filter-name>


### PR DESCRIPTION
~~Added new property~~
~~`eva.server.security.enabled`~~

After enabled it can be used to check a Bearer oauth2 credential against a server using the standard configuration properties from Spring-oauth2.

`security.oauth2.resource.user-info-uri`
