### PR TITLE
Version upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+
+language: java
+
+jdk:
+  - oraclejdk8
+
+env:
+  - OPENCGA_HOME=$TRAVIS_BUILD_DIR/opencga/opencga-app/build
+
+before_install:
+  - chmod +x install-dependencies.sh
+
+install:
+  - ./install-dependencies.sh
+
+script:
+  - mvn compile

--- a/eva-lib/pom.xml
+++ b/eva-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>eva</artifactId>
-        <version>1.3</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>eva</artifactId>
         <groupId>uk.ac.ebi.eva</groupId>
-        <version>1.3</version>
+        <version>1.3.1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,10 @@
+git clone -b hotfix/0.4 https://github.com/ebivariation/biodata.git
+git clone -b hotfix/0.5 https://github.com/ebivariation/opencga.git
+git clone -b hotfix/0.1 https://github.com/ebivariation/variation-commons.git
+
+cd biodata && mvn install
+cd ..
+cd opencga && mvn install -DskipTests
+cd ..
+cd variation-commons && mvn install
+

--- a/pom.xml
+++ b/pom.xml
@@ -7,22 +7,22 @@
     <groupId>uk.ac.ebi.eva</groupId>
     <artifactId>eva</artifactId>
     <packaging>pom</packaging>
-    <version>1.3</version>
+    <version>1.3.1</version>
 
     <modules>
         <module>eva-lib</module>
         <module>eva-server</module>
     </modules>
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.7.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.3.7.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
 
     <properties>
-        <opencga.version>0.5.2</opencga.version>
+        <opencga.version>0.5.3</opencga.version>
         <compileSource>1.8</compileSource>
     </properties>
 


### PR DESCRIPTION
Requires code from https://github.com/EBIvariation/opencga/pull/1 and the Travis script to be modified to clone the latest dependencies versions.

* OpenCGA upgraded to 0.5.3
* Project upgraded to 1.3.1