### PR TITLE
Fixed bug in named query

### DIFF
--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/entity/File.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/entity/File.java
@@ -34,7 +34,7 @@ import javax.persistence.*;
             query = "select distinct bf.filename, f.ftp_file " +
                     "from browsable_file bf "+
                     "left join file f on bf.file_id = f.file_id "+
-                    "where bf.filename in :filenames;",
+                    "where bf.filename in :filenames",
             resultSetMapping = "fileFtpReference"
     )
 })


### PR DESCRIPTION
The ';' causes an exception (parameter [filenames] not found)