### PR TITLE
EVA-349 Web service for VEP and Ensembl cache used

### DIFF
--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/MongoConfiguration.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/MongoConfiguration.java
@@ -46,9 +46,17 @@ public class MongoConfiguration {
     @Value("${eva.mongo.collections.files}")
     private String mongoCollectionsFiles;
 
+    @Value("${eva.mongo.collections.annotation_metadata}")
+    private String mongoCollectionsAnnotationMetadata;
+
     @Bean
     public String mongoCollectionsFiles() {
         return mongoCollectionsFiles;
+    }
+
+    @Bean
+    public String mongoCollectionsAnnotationMetadata() {
+        return mongoCollectionsAnnotationMetadata;
     }
 
     @Bean

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepository.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepository.java
@@ -21,8 +21,17 @@ import uk.ac.ebi.eva.commons.models.metadata.AnnotationMetadata;
 
 import java.util.List;
 
+/**
+ * Spring MongoRepository for querying collection of AnnotationMetadata documents
+ */
 public interface AnnotationMetadataRepository extends MongoRepository<AnnotationMetadata, String> {
 
+    /**
+     * Query for all AnnotationMetadata from collection, ordered first by cache version descending and then vep version
+     * descending.
+     *
+     * @return List of AnnotationMetadata objects
+     */
     List<AnnotationMetadata> findAllByOrderByCacheVersionDescVepVersionDesc();
 
 }

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepository.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.lib.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import uk.ac.ebi.eva.commons.models.metadata.AnnotationMetadata;
+
+import java.util.List;
+
+public interface AnnotationMetadataRepository extends MongoRepository<AnnotationMetadata, String> {
+
+    List<AnnotationMetadata> findAll();
+
+}

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepository.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepository.java
@@ -23,6 +23,6 @@ import java.util.List;
 
 public interface AnnotationMetadataRepository extends MongoRepository<AnnotationMetadata, String> {
 
-    List<AnnotationMetadata> findAll();
+    List<AnnotationMetadata> findAllByOrderByCacheVersionDescVepVersionDesc();
 
 }

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
@@ -62,7 +62,8 @@ public class AnnotationMetadataRepositoryTest {
         AnnotationMetadata prevAnnotationMetadata = annotationMetadataList.get(0);
         for (AnnotationMetadata curAnnotationMetadata :
                 annotationMetadataList.subList(1, annotationMetadataList.size())) {
-            assertTrue(0 >= curAnnotationMetadata.getCacheVersion().compareTo(prevAnnotationMetadata.getCacheVersion()));
+            assertTrue(curAnnotationMetadata.getCacheVersion().compareTo(prevAnnotationMetadata.getCacheVersion())
+                               <= 0);
         }
     }
 
@@ -73,7 +74,8 @@ public class AnnotationMetadataRepositoryTest {
         for (AnnotationMetadata curAnnotationMetadata :
                 annotationMetadataList.subList(1, annotationMetadataList.size())) {
             if (curAnnotationMetadata.getCacheVersion().equals(prevAnnotationMetadata.getCacheVersion())) {
-                assertTrue(0 >= curAnnotationMetadata.getCacheVersion().compareTo(prevAnnotationMetadata.getCacheVersion()));
+                assertTrue(curAnnotationMetadata.getCacheVersion().compareTo(prevAnnotationMetadata.getCacheVersion())
+                                   <= 0);
             }
         }
     }

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
@@ -1,0 +1,43 @@
+package uk.ac.ebi.eva.lib.repository;
+
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import uk.ac.ebi.eva.commons.models.metadata.AnnotationMetadata;
+import uk.ac.ebi.eva.lib.configuration.MongoRepositoryTestConfiguration;
+
+import java.util.List;
+
+import static com.lordofthejars.nosqlunit.mongodb.MongoDbRule.MongoDbRuleBuilder.newMongoDbRule;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {MongoRepositoryTestConfiguration.class})
+@UsingDataSet(locations = {"/test-data/annotation_metadata.json"})
+public class AnnotationMetadataRepositoryTest {
+
+    private static final String TEST_DB = "test-db";
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private AnnotationMetadataRepository repository;
+
+    @Rule
+    public MongoDbRule mongoDbRule = newMongoDbRule().defaultSpringMongoDb(TEST_DB);
+
+    @Test
+    public void findAllOrderByvepVersion() throws Exception {
+        List<AnnotationMetadata> annotationMetadataList = repository.findAll();
+        assertEquals(4, annotationMetadataList.size());
+    }
+
+}

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static com.lordofthejars.nosqlunit.mongodb.MongoDbRule.MongoDbRuleBuilder.newMongoDbRule;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {MongoRepositoryTestConfiguration.class})
@@ -35,9 +36,33 @@ public class AnnotationMetadataRepositoryTest {
     public MongoDbRule mongoDbRule = newMongoDbRule().defaultSpringMongoDb(TEST_DB);
 
     @Test
-    public void findAllOrderByvepVersion() throws Exception {
-        List<AnnotationMetadata> annotationMetadataList = repository.findAll();
+    public void testFindAllByOrderByCacheVersionDescVepVersionDescSize() throws Exception {
+        List<AnnotationMetadata> annotationMetadataList = repository.findAllByOrderByCacheVersionDescVepVersionDesc();
         assertEquals(4, annotationMetadataList.size());
+    }
+
+    @Test
+    public void testFindAllByOrderByCacheVersionDescVepVersionDescCacheVersionOrder() throws Exception {
+        List<AnnotationMetadata> annotationMetadataList = repository.findAllByOrderByCacheVersionDescVepVersionDesc();
+        AnnotationMetadata prevAnnotationMetadata = annotationMetadataList.get(0);
+        for (AnnotationMetadata curAnnotationMetadata :
+                annotationMetadataList.subList(1, annotationMetadataList.size())) {
+            assertTrue(Integer.parseInt(curAnnotationMetadata.getCacheVersion())
+                               <= Integer.parseInt(prevAnnotationMetadata.getCacheVersion()));
+        }
+    }
+
+    @Test
+    public void testFindAllByOrderByCacheVersionDescVepVersionDescVepVersionOrder() throws Exception {
+        List<AnnotationMetadata> annotationMetadataList = repository.findAllByOrderByCacheVersionDescVepVersionDesc();
+        AnnotationMetadata prevAnnotationMetadata = annotationMetadataList.get(0);
+        for (AnnotationMetadata curAnnotationMetadata :
+                annotationMetadataList.subList(1, annotationMetadataList.size())) {
+            if (curAnnotationMetadata.getCacheVersion().equals(prevAnnotationMetadata.getCacheVersion())) {
+                assertTrue(Integer.parseInt(curAnnotationMetadata.getCacheVersion())
+                                   <= Integer.parseInt(prevAnnotationMetadata.getCacheVersion()));
+            }
+        }
     }
 
 }

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
@@ -62,8 +62,7 @@ public class AnnotationMetadataRepositoryTest {
         AnnotationMetadata prevAnnotationMetadata = annotationMetadataList.get(0);
         for (AnnotationMetadata curAnnotationMetadata :
                 annotationMetadataList.subList(1, annotationMetadataList.size())) {
-            assertTrue(Integer.parseInt(curAnnotationMetadata.getCacheVersion())
-                               <= Integer.parseInt(prevAnnotationMetadata.getCacheVersion()));
+            assertTrue(0 >= curAnnotationMetadata.getCacheVersion().compareTo(prevAnnotationMetadata.getCacheVersion()));
         }
     }
 
@@ -74,8 +73,7 @@ public class AnnotationMetadataRepositoryTest {
         for (AnnotationMetadata curAnnotationMetadata :
                 annotationMetadataList.subList(1, annotationMetadataList.size())) {
             if (curAnnotationMetadata.getCacheVersion().equals(prevAnnotationMetadata.getCacheVersion())) {
-                assertTrue(Integer.parseInt(curAnnotationMetadata.getCacheVersion())
-                                   <= Integer.parseInt(prevAnnotationMetadata.getCacheVersion()));
+                assertTrue(0 >= curAnnotationMetadata.getCacheVersion().compareTo(prevAnnotationMetadata.getCacheVersion()));
             }
         }
     }

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/repository/AnnotationMetadataRepositoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.ebi.eva.lib.repository;
 
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;

--- a/eva-lib/src/test/resources/eva.properties
+++ b/eva-lib/src/test/resources/eva.properties
@@ -7,6 +7,7 @@ eva.mongo.read-preference=
 
 eva.mongo.collections.variants=vars
 eva.mongo.collections.files=files
+eva.mongo.collections.annotation_metadata=annotation_metadata
 
 eva.version=
 

--- a/eva-lib/src/test/resources/test-data/annotation_metadata.json
+++ b/eva-lib/src/test/resources/test-data/annotation_metadata.json
@@ -1,0 +1,8 @@
+{
+"annotation_metadata":[
+  { "_id" : "74_74", "_class" : "uk.ac.ebi.eva.commons.models.metadata.AnnotationMetadata", "vepVersion" : "74", "cacheVersion" : "74" },
+  { "_id" : "86_86", "_class" : "uk.ac.ebi.eva.commons.models.metadata.AnnotationMetadata", "vepVersion" : "86", "cacheVersion" : "86" },
+  { "_id" : "85_76", "_class" : "uk.ac.ebi.eva.commons.models.metadata.AnnotationMetadata", "vepVersion" : "75", "cacheVersion" : "76" },
+  { "_id" : "78_77", "_class" : "uk.ac.ebi.eva.commons.models.metadata.AnnotationMetadata", "vepVersion" : "78", "cacheVersion" : "77" }
+]
+}

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>variation-commons</artifactId>
-            <version>0.2-SNAPSHOT</version>
+            <version>0.3-SNAPSHOT</version>
         </dependency>
 
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/AnnotationMetadataWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/AnnotationMetadataWSServer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.server.ws;
+
+import io.swagger.annotations.Api;
+import org.opencb.datastore.core.QueryResponse;
+import org.opencb.datastore.core.QueryResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import uk.ac.ebi.eva.commons.models.metadata.AnnotationMetadata;
+import uk.ac.ebi.eva.lib.repository.AnnotationMetadataRepository;
+import uk.ac.ebi.eva.lib.utils.DBAdaptorConnector;
+import uk.ac.ebi.eva.lib.utils.MultiMongoDbFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/v1/annotation", produces = "application/json")
+@Api(tags = {"annotation"})
+public class AnnotationMetadataWSServer extends EvaWSServer {
+
+    @Autowired
+    private AnnotationMetadataRepository repository;
+
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    @ResponseBody
+    public QueryResponse getAnnotationMetadata(@RequestParam(name = "species") String species,
+                                               HttpServletResponse response) {
+        if (species.isEmpty()) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return setQueryResponse("Please specify a species");
+        }
+
+        MultiMongoDbFactory.setDatabaseNameForCurrentThread(DBAdaptorConnector.getDBName(species));
+        List<AnnotationMetadata> annotationMetadataList = repository.findAllByOrderByCacheVersionDescVepVersionDesc();
+        QueryResult<AnnotationMetadata> queryResult = buildQueryResult(annotationMetadataList);
+        return setQueryResponse(queryResult);
+    }
+
+}

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/AnnotationMetadataWSServerTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/AnnotationMetadataWSServerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.server.ws;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opencb.datastore.core.QueryResponse;
+import org.opencb.datastore.core.QueryResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import uk.ac.ebi.eva.commons.models.metadata.AnnotationMetadata;
+import uk.ac.ebi.eva.lib.repository.AnnotationMetadataRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AnnotationMetadataWSServerTest {
+
+    private List<AnnotationMetadata> annotationMetadataList;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @MockBean
+    private AnnotationMetadataRepository annotationMetadataRepository;
+
+    @Before
+    public void setUp() throws Exception {
+        annotationMetadataList = Arrays.asList(new AnnotationMetadata("75", "75"),
+                                               new AnnotationMetadata("74", "74"));
+
+        given(annotationMetadataRepository.findAllByOrderByCacheVersionDescVepVersionDesc())
+                .willReturn(annotationMetadataList);
+    }
+
+    @Test
+    public void testFetAnnotationMetadata() {
+        String url = "/v1/annotation?species=mmusculus_grcm38";
+        ResponseEntity<QueryResponse<QueryResult<AnnotationMetadata>>> response = restTemplate.exchange(
+                url, HttpMethod.GET, null,
+                new ParameterizedTypeReference<QueryResponse<QueryResult<AnnotationMetadata>>>() {});
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        QueryResponse<QueryResult<AnnotationMetadata>> queryResponse = response.getBody();
+        assertEquals(1, queryResponse.getResponse().size());
+
+        List<AnnotationMetadata> results = queryResponse.getResponse().get(0).getResult();
+        assertEquals(annotationMetadataList.size(), results.size());
+
+        for (AnnotationMetadata result : results) {
+            assertTrue(annotationMetadataList.contains(result));
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
                 <artifactId>variation-commons</artifactId>
-                <version>0.2-SNAPSHOT</version>
+                <version>0.3-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>


### PR DESCRIPTION
- Repository for AnnotationMetadata, and tests
- Webservice for AnnotationMetadata, using above repository 
- https://github.com/EBIvariation/variation-commons/pull/29 Needs to be merged first, because this PR relies upon it, which is why the tests are failing for this PR