### PR TITLE
EVA-770 Display populated HGVS field

### DIFF
--- a/eva-lib/pom.xml
+++ b/eva-lib/pom.xml
@@ -14,16 +14,6 @@
     <dependencies>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
-            <artifactId>opencga-storage-mongodb</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mongodb</groupId>
-                    <artifactId>mongo-java-driver</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>variation-commons</artifactId>
         </dependency>
         <dependency>

--- a/eva-lib/pom.xml
+++ b/eva-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>eva</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>eva</artifactId>
         <groupId>uk.ac.ebi.eva</groupId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -49,21 +49,8 @@
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
-            <artifactId>opencga-storage-mongodb</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mongodb</groupId>
-                    <artifactId>mongo-java-driver</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>variation-commons</artifactId>
-            <version>0.2-SNAPSHOT</version>
         </dependency>
-
-
 
         <dependency>
             <groupId>asm</groupId>

--- a/eva-server/src/main/resources/application.properties
+++ b/eva-server/src/main/resources/application.properties
@@ -20,3 +20,6 @@ springfox.documentation.swagger.v2.path=/webservices/api
 #security.oauth2.resource.user-info-uri = ...
 
 eva.mongo.collections.files=@eva.mongo.collections.files@
+eva.mongo.collections.variants=@eva.mongo.collections.variants@
+eva.mongo.collections.annotation_metadata=@eva.mongo.collections.annotation_metadata@
+

--- a/eva-server/src/main/resources/eva.properties
+++ b/eva-server/src/main/resources/eva.properties
@@ -4,8 +4,9 @@ eva.mongo.passwd=@eva.mongo.passwd@
 eva.mongo.auth.db=@eva.mongo.auth.db@
 eva.mongo.read-preference=@eva.mongo.read-preference@
 
-eva.mongo.collections.variants=@eva.mongo.collections.variants@
 eva.mongo.collections.files=@eva.mongo.collections.files@
+eva.mongo.collections.variants=@eva.mongo.collections.variants@
+eva.mongo.collections.annotation_metadata=@eva.mongo.collections.annotation_metadata@
 
 eva.version=@eva.version@
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
     </parent>
 
     <properties>
-        <opencga.version>0.5.4</opencga.version>
         <compileSource>1.8</compileSource>
     </properties>
 
@@ -48,42 +47,7 @@
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
                 <artifactId>variation-commons</artifactId>
-                <version>0.2-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>uk.ac.ebi.eva</groupId>
-                <artifactId>opencga-storage-mongodb</artifactId>
-                <version>${opencga.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.sun.jersey</groupId>
-                        <artifactId>jersey-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.jersey</groupId>
-                        <artifactId>jersey-client</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.servlet</groupId>
-                        <artifactId>servlet-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.jersey.contribs</groupId>
-                        <artifactId>jersey-multipart</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-databind</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-simple</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.mongodb</groupId>
-                        <artifactId>mongo-java-driver</artifactId>
-                    </exclusion>
-                </exclusions>
+                <version>0.2.1</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>uk.ac.ebi.eva</groupId>
     <artifactId>eva</artifactId>
     <packaging>pom</packaging>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.4</version>
 
     <modules>
         <module>eva-lib</module>


### PR DESCRIPTION
* Using variation-commons version 0.2.1 including bugfix from [variation-commons#34](https://github.com/EBIvariation/variation-commons/pull/34), which needs to be pushed to Artifactory in order for this build to pass
* Version bumped to 1.4 final
* Populates correctly the HGVS
* OpenCGA dependency managed in variation-commons for consistency across all EVA repositories

**Note:** These changes will need to be ported to branch 1.5-develop.