### PR TITLE
EVA-797 Implement filter at API level

### DIFF
--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/models/ga4gh/GAVariantFactory.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/models/ga4gh/GAVariantFactory.java
@@ -16,7 +16,7 @@
 package uk.ac.ebi.eva.lib.models.ga4gh;
 
 import uk.ac.ebi.eva.commons.core.models.ws.VariantSourceEntryWithSampleNames;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,11 +34,11 @@ public class GAVariantFactory {
      * @param variants List of variants to transform
      * @return GA4GH variants representing the same data as the internal API ones
      */
-    public static List<GAVariant> create(List<VariantWithSamplesAndAnnotations> variants){//, Map<String, List<String>>
+    public static List<GAVariant> create(List<VariantWithSamplesAndAnnotation> variants){//, Map<String, List<String>>
         // samplesPerSource) {
         Set<GAVariant> gaVariants = new LinkedHashSet<>();
 
-        for (VariantWithSamplesAndAnnotations variant : variants) {
+        for (VariantWithSamplesAndAnnotation variant : variants) {
             String id = String.format("%s_%d_%s_%s", variant.getChromosome(), variant.getStart(), variant.getReference(), variant.getAlternate());
 
             Set<String> variantIds = variant.getIds();

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>variation-commons</artifactId>
-            <version>0.3-SNAPSHOT</version>
+            <version>0.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/configuration/JacksonConfiguration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/configuration/JacksonConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import uk.ac.ebi.eva.commons.core.models.VariantStatistics;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.lib.json.QueryResponseMixin;
 import uk.ac.ebi.eva.lib.json.VariantMixin;
 import uk.ac.ebi.eva.lib.json.VariantStatisticsMixin;
@@ -38,7 +38,7 @@ public class JacksonConfiguration {
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-        objectMapper.addMixIn(VariantWithSamplesAndAnnotations.class, VariantMixin.class);
+        objectMapper.addMixIn(VariantWithSamplesAndAnnotation.class, VariantMixin.class);
         objectMapper.addMixIn(QueryResponse.class, QueryResponseMixin.class);
         objectMapper.addMixIn(VariantStudy.class, VariantStudyMixin.class);
         objectMapper.addMixIn(VariantStatistics.class, VariantStatisticsMixin.class);

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
@@ -62,8 +62,8 @@ public class GeneWSServer extends EvaWSServer {
                                            @RequestParam(name = "polyphen", required = false) String polyphenScore,
                                            @RequestParam(name = "sift", required = false) String siftScore,
                                            @RequestParam(name = "exclude", required = false) List<String> exclude,
-                                           @RequestParam(name = "annotationVepVersion", required = false) String annotationVepVersion,
-                                           @RequestParam(name = "annotationVepCacheversion", required = false) String annotationVepCacheversion,
+                                           @RequestParam(name = "annotation-vep-version", required = false) String annotationVepVersion,
+                                           @RequestParam(name = "annotation-vep-cache-version", required = false) String annotationVepCacheVersion,
                                            HttpServletResponse response) {
         initializeQuery();
 
@@ -78,8 +78,8 @@ public class GeneWSServer extends EvaWSServer {
                 .getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies, consequenceType);
 
         AnnotationMetadata annotationMetadata = null;
-        if (annotationVepVersion != null && annotationVepCacheversion != null) {
-            annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion);
+        if (annotationVepVersion != null && annotationVepCacheVersion != null) {
+            annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheVersion);
         }
 
         List<VariantWithSamplesAndAnnotation> variantEntities =

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
@@ -26,7 +26,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+
+import uk.ac.ebi.eva.commons.core.models.AnnotationMetadata;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.filter.FilterBuilder;
 import uk.ac.ebi.eva.commons.mongodb.filter.VariantRepositoryFilter;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
@@ -60,6 +62,8 @@ public class GeneWSServer extends EvaWSServer {
                                            @RequestParam(name = "polyphen", required = false) String polyphenScore,
                                            @RequestParam(name = "sift", required = false) String siftScore,
                                            @RequestParam(name = "exclude", required = false) List<String> exclude,
+                                           @RequestParam(name = "annotationVepVersion", required = false) String annotationVepVersion,
+                                           @RequestParam(name = "annotationVepCacheversion", required = false) String annotationVepCacheversion,
                                            HttpServletResponse response) {
         initializeQuery();
 
@@ -70,16 +74,17 @@ public class GeneWSServer extends EvaWSServer {
 
         MultiMongoDbFactory.setDatabaseNameForCurrentThread(DBAdaptorConnector.getDBName(species));
 
-        List<VariantRepositoryFilter> filters =
-                new FilterBuilder().getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies,
-                        consequenceType);
+        List<VariantRepositoryFilter> filters = new FilterBuilder()
+                .getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies, consequenceType);
 
-        List<VariantWithSamplesAndAnnotations> variantEntities =
-                service.findByGenesAndComplexFilters(geneIds, filters, exclude,
-                        Utils.getPageRequest(queryOptions));
+        List<VariantWithSamplesAndAnnotation> variantEntities =
+                service.findByGenesAndComplexFilters(geneIds, filters,
+                                                     new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion),
+                                                     exclude, Utils.getPageRequest(queryOptions));
+
         Long numTotalResults = service.countByGenesAndComplexFilters(geneIds, filters);
 
-        QueryResult<VariantWithSamplesAndAnnotations> queryResult = buildQueryResult(variantEntities, numTotalResults);
+        QueryResult<VariantWithSamplesAndAnnotation> queryResult = buildQueryResult(variantEntities, numTotalResults);
         return setQueryResponse(queryResult);
     }
 
@@ -92,9 +97,11 @@ public class GeneWSServer extends EvaWSServer {
                                                @RequestParam(name = "polyphen", defaultValue = "") String polyphenScore,
                                                @RequestParam(name = "sift", defaultValue = "") String siftScore,
                                                @RequestParam(name = "exclude", required = false) List<String> exclude,
+                                               @RequestParam(name = "annotationVepVersion", required = false) String annotationVepVersion,
+                                               @RequestParam(name = "annotationVepCacheversion", required = false) String annotationVepCacheversion,
                                                HttpServletResponse response) {
         return getVariantsByGene(geneIds, species, studies, consequenceType, maf, polyphenScore, siftScore, exclude,
-                response);
+                                 annotationVepVersion, annotationVepCacheversion, response);
     }
 
 }

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
@@ -31,6 +31,7 @@ import uk.ac.ebi.eva.commons.core.models.AnnotationMetadata;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.filter.FilterBuilder;
 import uk.ac.ebi.eva.commons.mongodb.filter.VariantRepositoryFilter;
+import uk.ac.ebi.eva.commons.mongodb.services.AnnotationMetadataNotFoundException;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.utils.DBAdaptorConnector;
 import uk.ac.ebi.eva.lib.utils.MultiMongoDbFactory;
@@ -64,7 +65,7 @@ public class GeneWSServer extends EvaWSServer {
                                            @RequestParam(name = "exclude", required = false) List<String> exclude,
                                            @RequestParam(name = "annotation-vep-version", required = false) String annotationVepVersion,
                                            @RequestParam(name = "annotation-vep-cache-version", required = false) String annotationVepCacheVersion,
-                                           HttpServletResponse response) {
+                                           HttpServletResponse response) throws AnnotationMetadataNotFoundException {
         initializeQuery();
 
         if (species.isEmpty()) {
@@ -102,7 +103,7 @@ public class GeneWSServer extends EvaWSServer {
                                                @RequestParam(name = "exclude", required = false) List<String> exclude,
                                                @RequestParam(name = "annotationVepVersion", required = false) String annotationVepVersion,
                                                @RequestParam(name = "annotationVepCacheversion", required = false) String annotationVepCacheversion,
-                                               HttpServletResponse response) {
+                                               HttpServletResponse response) throws AnnotationMetadataNotFoundException {
         return getVariantsByGene(geneIds, species, studies, consequenceType, maf, polyphenScore, siftScore, exclude,
                                  annotationVepVersion, annotationVepCacheversion, response);
     }

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
@@ -63,8 +63,8 @@ public class GeneWSServer extends EvaWSServer {
                                            @RequestParam(name = "polyphen", required = false) String polyphenScore,
                                            @RequestParam(name = "sift", required = false) String siftScore,
                                            @RequestParam(name = "exclude", required = false) List<String> exclude,
-                                           @RequestParam(name = "annotation-vep-version", required = false) String annotationVepVersion,
-                                           @RequestParam(name = "annotation-vep-cache-version", required = false) String annotationVepCacheVersion,
+                                           @RequestParam(name = "annot-vep-version", required = false) String annotationVepVersion,
+                                           @RequestParam(name = "annot-vep-cache-version", required = false) String annotationVepCacheVersion,
                                            HttpServletResponse response) throws AnnotationMetadataNotFoundException {
         initializeQuery();
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
@@ -70,7 +70,7 @@ public class GeneWSServer extends EvaWSServer {
 
         if (annotationVepVersion == null ^ annotationVepCacheVersion == null) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return setQueryResponse("Please specify either both annotation vep version and annotation vep cache version, or neither");
+            return setQueryResponse("Please specify either both annotation VEP version and annotation VEP cache version, or neither");
         }
 
         if (species.isEmpty()) {
@@ -106,8 +106,8 @@ public class GeneWSServer extends EvaWSServer {
                                                @RequestParam(name = "polyphen", defaultValue = "") String polyphenScore,
                                                @RequestParam(name = "sift", defaultValue = "") String siftScore,
                                                @RequestParam(name = "exclude", required = false) List<String> exclude,
-                                               @RequestParam(name = "annotationVepVersion", required = false) String annotationVepVersion,
-                                               @RequestParam(name = "annotationVepCacheversion", required = false) String annotationVepCacheversion,
+                                               @RequestParam(name = "annot-vep-version", required = false) String annotationVepVersion,
+                                               @RequestParam(name = "annot-vep-cache-version", required = false) String annotationVepCacheversion,
                                                HttpServletResponse response) throws AnnotationMetadataNotFoundException {
         return getVariantsByGene(geneIds, species, studies, consequenceType, maf, polyphenScore, siftScore, exclude,
                                  annotationVepVersion, annotationVepCacheversion, response);

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
@@ -68,6 +68,11 @@ public class GeneWSServer extends EvaWSServer {
                                            HttpServletResponse response) throws AnnotationMetadataNotFoundException {
         initializeQuery();
 
+        if (annotationVepVersion == null ^ annotationVepCacheVersion == null) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return setQueryResponse("Please specify either both annotation vep version and annotation vep cache version, or neither");
+        }
+
         if (species.isEmpty()) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return setQueryResponse("Please specify a species");

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/GeneWSServer.java
@@ -77,10 +77,13 @@ public class GeneWSServer extends EvaWSServer {
         List<VariantRepositoryFilter> filters = new FilterBuilder()
                 .getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies, consequenceType);
 
+        AnnotationMetadata annotationMetadata = null;
+        if (annotationVepVersion != null && annotationVepCacheversion != null) {
+            annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion);
+        }
+
         List<VariantWithSamplesAndAnnotation> variantEntities =
-                service.findByGenesAndComplexFilters(geneIds, filters,
-                                                     new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion),
-                                                     exclude, Utils.getPageRequest(queryOptions));
+                service.findByGenesAndComplexFilters(geneIds, filters, annotationMetadata, exclude, Utils.getPageRequest(queryOptions));
 
         Long numTotalResults = service.countByGenesAndComplexFilters(geneIds, filters);
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
@@ -30,8 +30,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import uk.ac.ebi.eva.commons.core.models.AnnotationMetadata;
 import uk.ac.ebi.eva.commons.core.models.Region;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.filter.FilterBuilder;
 import uk.ac.ebi.eva.commons.mongodb.filter.VariantRepositoryFilter;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
@@ -83,8 +85,7 @@ public class RegionWSServer extends EvaWSServer {
         MultiMongoDbFactory.setDatabaseNameForCurrentThread(DBAdaptorConnector.getDBName(species));
 
         List<VariantRepositoryFilter> filters = new FilterBuilder()
-                .getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies, consequenceType,
-                                                   annotationVepVersion, annotationVepCacheversion);
+                .getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies, consequenceType);
         List<Region> regions = Region.parseRegions(regionId);
         PageRequest pageRequest = Utils.getPageRequest(queryOptions);
 
@@ -100,12 +101,14 @@ public class RegionWSServer extends EvaWSServer {
             }
         }
 
-        List<VariantWithSamplesAndAnnotations> variantEntities =
-                service.findByRegionsAndComplexFilters(regions, filters, excludeMapped, pageRequest);
+        List<VariantWithSamplesAndAnnotation> variantEntities =
+                service.findByRegionsAndComplexFilters(regions, filters,
+                                                       new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion),
+                                                       excludeMapped, pageRequest);
 
         Long numTotalResults = service.countByRegionsAndComplexFilters(regions, filters);
 
-        QueryResult<VariantWithSamplesAndAnnotations> queryResult = buildQueryResult(variantEntities, numTotalResults);
+        QueryResult<VariantWithSamplesAndAnnotation> queryResult = buildQueryResult(variantEntities, numTotalResults);
         return setQueryResponse(queryResult);
     }
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
@@ -69,6 +69,8 @@ public class RegionWSServer extends EvaWSServer {
                                              @RequestParam(name = "polyphen", required = false) String polyphenScore,
                                              @RequestParam(name = "sift", required = false) String siftScore,
                                              @RequestParam(name = "exclude", required = false) List<String> exclude,
+                                             @RequestParam(name = "annotationVepVersion", required = false) String annotationVepVersion,
+                                             @RequestParam(name = "annotationVepCacheversion", required = false) String annotationVepCacheversion,
                                              HttpServletResponse response)
             throws IOException {
         initializeQuery();
@@ -81,7 +83,8 @@ public class RegionWSServer extends EvaWSServer {
         MultiMongoDbFactory.setDatabaseNameForCurrentThread(DBAdaptorConnector.getDBName(species));
 
         List<VariantRepositoryFilter> filters = new FilterBuilder()
-                .getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies, consequenceType);
+                .getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies, consequenceType,
+                                                   annotationVepVersion, annotationVepCacheversion);
         List<Region> regions = Region.parseRegions(regionId);
         PageRequest pageRequest = Utils.getPageRequest(queryOptions);
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
@@ -72,8 +72,8 @@ public class RegionWSServer extends EvaWSServer {
                                              @RequestParam(name = "polyphen", required = false) String polyphenScore,
                                              @RequestParam(name = "sift", required = false) String siftScore,
                                              @RequestParam(name = "exclude", required = false) List<String> exclude,
-                                             @RequestParam(name = "annotationVepVersion", required = false) String annotationVepVersion,
-                                             @RequestParam(name = "annotationVepCacheversion", required = false) String annotationVepCacheversion,
+                                             @RequestParam(name = "annotation-vep-version", required = false) String annotationVepVersion,
+                                             @RequestParam(name = "annotation-vep-cache-version", required = false) String annotationVepCacheVersion,
                                              HttpServletResponse response)
             throws IOException {
         initializeQuery();
@@ -103,8 +103,8 @@ public class RegionWSServer extends EvaWSServer {
         }
 
         AnnotationMetadata annotationMetadata = null;
-        if (annotationVepVersion != null && annotationVepCacheversion != null) {
-            annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion);
+        if (annotationVepVersion != null && annotationVepCacheVersion != null) {
+            annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheVersion);
         }
 
         List<VariantWithSamplesAndAnnotation> variantEntities =

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
@@ -73,8 +73,8 @@ public class RegionWSServer extends EvaWSServer {
                                              @RequestParam(name = "polyphen", required = false) String polyphenScore,
                                              @RequestParam(name = "sift", required = false) String siftScore,
                                              @RequestParam(name = "exclude", required = false) List<String> exclude,
-                                             @RequestParam(name = "annotation-vep-version", required = false) String annotationVepVersion,
-                                             @RequestParam(name = "annotation-vep-cache-version", required = false) String annotationVepCacheVersion,
+                                             @RequestParam(name = "annot-vep-version", required = false) String annotationVepVersion,
+                                             @RequestParam(name = "annot-vep-cache-version", required = false) String annotationVepCacheVersion,
                                              HttpServletResponse response)
             throws IOException, AnnotationMetadataNotFoundException {
         initializeQuery();

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
@@ -81,7 +81,7 @@ public class RegionWSServer extends EvaWSServer {
 
         if (annotationVepVersion == null ^ annotationVepCacheVersion == null) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return setQueryResponse("Please specify either both annotation vep version and annotation vep cache version, or neither");
+            return setQueryResponse("Please specify either both annotation VEP version and annotation VEP cache version, or neither");
         }
 
         if (species.isEmpty()) {

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import uk.ac.ebi.eva.commons.core.models.Annotation;
 import uk.ac.ebi.eva.commons.core.models.AnnotationMetadata;
 import uk.ac.ebi.eva.commons.core.models.Region;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
@@ -101,10 +102,13 @@ public class RegionWSServer extends EvaWSServer {
             }
         }
 
+        AnnotationMetadata annotationMetadata = null;
+        if (annotationVepVersion != null && annotationVepCacheversion != null) {
+            annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion);
+        }
+
         List<VariantWithSamplesAndAnnotation> variantEntities =
-                service.findByRegionsAndComplexFilters(regions, filters,
-                                                       new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion),
-                                                       excludeMapped, pageRequest);
+                service.findByRegionsAndComplexFilters(regions, filters, annotationMetadata, excludeMapped, pageRequest);
 
         Long numTotalResults = service.countByRegionsAndComplexFilters(regions, filters);
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
@@ -79,6 +79,11 @@ public class RegionWSServer extends EvaWSServer {
             throws IOException, AnnotationMetadataNotFoundException {
         initializeQuery();
 
+        if (annotationVepVersion == null ^ annotationVepCacheVersion == null) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return setQueryResponse("Please specify either both annotation vep version and annotation vep cache version, or neither");
+        }
+
         if (species.isEmpty()) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return setQueryResponse("Please specify a species");

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
@@ -37,6 +37,7 @@ import uk.ac.ebi.eva.commons.core.models.Region;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.filter.FilterBuilder;
 import uk.ac.ebi.eva.commons.mongodb.filter.VariantRepositoryFilter;
+import uk.ac.ebi.eva.commons.mongodb.services.AnnotationMetadataNotFoundException;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.utils.DBAdaptorConnector;
 import uk.ac.ebi.eva.lib.utils.MultiMongoDbFactory;
@@ -75,7 +76,7 @@ public class RegionWSServer extends EvaWSServer {
                                              @RequestParam(name = "annotation-vep-version", required = false) String annotationVepVersion,
                                              @RequestParam(name = "annotation-vep-cache-version", required = false) String annotationVepCacheVersion,
                                              HttpServletResponse response)
-            throws IOException {
+            throws IOException, AnnotationMetadataNotFoundException {
         initializeQuery();
 
         if (species.isEmpty()) {

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
@@ -75,7 +75,7 @@ public class VariantWSServer extends EvaWSServer {
 
         if (annotationVepVersion == null ^ annotationVepCacheVersion == null) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return setQueryResponse("Please specify either both annotation vep version and annotation vep cache version, or neither");
+            return setQueryResponse("Please specify either both annotation VEP version and annotation VEP cache version, or neither");
         }
 
         if (species.isEmpty()) {

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
@@ -73,6 +73,11 @@ public class VariantWSServer extends EvaWSServer {
             throws IOException, AnnotationMetadataNotFoundException {
         initializeQuery();
 
+        if (annotationVepVersion == null ^ annotationVepCacheVersion == null) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return setQueryResponse("Please specify either both annotation vep version and annotation vep cache version, or neither");
+        }
+
         if (species.isEmpty()) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return setQueryResponse("Please specify a species");

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
@@ -66,8 +66,8 @@ public class VariantWSServer extends EvaWSServer {
                                         @RequestParam(name = "polyphen", required = false) String polyphenScore,
                                         @RequestParam(name = "sift", required = false) String siftScore,
                                         @RequestParam(name = "exclude", required = false) List<String> exclude,
-                                        @RequestParam(name = "annotationVepVersion", required = false) String annotationVepVersion,
-                                        @RequestParam(name = "annotationVepCacheversion", required = false) String annotationVepCacheversion,
+                                        @RequestParam(name = "annotation-vep-version", required = false) String annotationVepVersion,
+                                        @RequestParam(name = "annotation-vep-cache-version", required = false) String annotationVepCacheVersion,
                                         HttpServletResponse response)
             throws IOException {
         initializeQuery();
@@ -86,7 +86,7 @@ public class VariantWSServer extends EvaWSServer {
             String[] regionId = variantId.split(":");
             String alternate = (regionId.length > 3) ? regionId[3] : null;
             variantEntities = queryByCoordinatesAndAlleles(regionId[0], Integer.parseInt(regionId[1]), regionId[2],
-                                                           alternate, annotationVepVersion, annotationVepCacheversion);
+                                                           alternate, annotationVepVersion, annotationVepCacheVersion);
             numTotalResults = (long) variantEntities.size();
         } else {
             List<VariantRepositoryFilter> filters = new FilterBuilder()
@@ -105,8 +105,8 @@ public class VariantWSServer extends EvaWSServer {
             }
 
             AnnotationMetadata annotationMetadata = null;
-            if (annotationVepVersion != null && annotationVepCacheversion != null) {
-                annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion);
+            if (annotationVepVersion != null && annotationVepCacheVersion != null) {
+                annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheVersion);
             }
 
             variantEntities = service.findByIdsAndComplexFilters(variantId, filters, annotationMetadata, excludeMapped,

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
@@ -104,9 +104,13 @@ public class VariantWSServer extends EvaWSServer {
                 }
             }
 
-            variantEntities = service.findByIdsAndComplexFilters(variantId, filters,
-                                                                 new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion),
-                                                                 excludeMapped, Utils.getPageRequest(queryOptions));
+            AnnotationMetadata annotationMetadata = null;
+            if (annotationVepVersion != null && annotationVepCacheversion != null) {
+                annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion);
+            }
+
+            variantEntities = service.findByIdsAndComplexFilters(variantId, filters, annotationMetadata, excludeMapped,
+                                                                 Utils.getPageRequest(queryOptions));
 
             numTotalResults = service.countByIdsAndComplexFilters(variantId, filters);
         }

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
@@ -33,6 +33,7 @@ import uk.ac.ebi.eva.commons.core.models.AnnotationMetadata;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.filter.FilterBuilder;
 import uk.ac.ebi.eva.commons.mongodb.filter.VariantRepositoryFilter;
+import uk.ac.ebi.eva.commons.mongodb.services.AnnotationMetadataNotFoundException;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.utils.DBAdaptorConnector;
 import uk.ac.ebi.eva.lib.utils.MultiMongoDbFactory;
@@ -69,7 +70,7 @@ public class VariantWSServer extends EvaWSServer {
                                         @RequestParam(name = "annotation-vep-version", required = false) String annotationVepVersion,
                                         @RequestParam(name = "annotation-vep-cache-version", required = false) String annotationVepCacheVersion,
                                         HttpServletResponse response)
-            throws IOException {
+            throws IOException, AnnotationMetadataNotFoundException {
         initializeQuery();
 
         if (species.isEmpty()) {
@@ -122,7 +123,7 @@ public class VariantWSServer extends EvaWSServer {
     private List<VariantWithSamplesAndAnnotation> queryByCoordinatesAndAlleles(String chromosome, int start,
                                                                                String reference, String alternate,
                                                                                String annotationVepVersion,
-                                                                               String annotationVepCacheversion) {
+                                                                               String annotationVepCacheversion) throws AnnotationMetadataNotFoundException {
         AnnotationMetadata annotationMetadata = null;
         if (annotationVepVersion != null && annotationVepCacheversion != null) {
             annotationMetadata = new AnnotationMetadata(annotationVepVersion, annotationVepCacheversion);
@@ -141,7 +142,7 @@ public class VariantWSServer extends EvaWSServer {
                                             @RequestParam(name = "studies", required = false) List<String> studies,
                                             @RequestParam("species") String species,
                                             HttpServletResponse response)
-            throws IOException {
+            throws IOException, AnnotationMetadataNotFoundException {
         initializeQuery();
 
         if (species.isEmpty()) {
@@ -189,7 +190,7 @@ public class VariantWSServer extends EvaWSServer {
     private List<VariantWithSamplesAndAnnotation> queryByCoordinatesAndAllelesAndStudyIds(String chromosome, int start,
                                                                                            String reference,
                                                                                            String alternate,
-                                                                                           List<String> studyIds) {
+                                                                                           List<String> studyIds) throws AnnotationMetadataNotFoundException {
         if (alternate != null) {
             return service.findByChromosomeAndStartAndReferenceAndAlternateAndStudyIn(chromosome, start, reference,
                                                                                       alternate, studyIds, null);

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
@@ -67,8 +67,8 @@ public class VariantWSServer extends EvaWSServer {
                                         @RequestParam(name = "polyphen", required = false) String polyphenScore,
                                         @RequestParam(name = "sift", required = false) String siftScore,
                                         @RequestParam(name = "exclude", required = false) List<String> exclude,
-                                        @RequestParam(name = "annotation-vep-version", required = false) String annotationVepVersion,
-                                        @RequestParam(name = "annotation-vep-cache-version", required = false) String annotationVepCacheVersion,
+                                        @RequestParam(name = "annot-vep-version", required = false) String annotationVepVersion,
+                                        @RequestParam(name = "annot-vep-cache-version", required = false) String annotationVepCacheVersion,
                                         HttpServletResponse response)
             throws IOException, AnnotationMetadataNotFoundException {
         initializeQuery();

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServer.java
@@ -64,6 +64,8 @@ public class VariantWSServer extends EvaWSServer {
                                         @RequestParam(name = "polyphen", required = false) String polyphenScore,
                                         @RequestParam(name = "sift", required = false) String siftScore,
                                         @RequestParam(name = "exclude", required = false) List<String> exclude,
+                                        @RequestParam(name = "annotationVepVersion", required = false) String annotationVepVersion,
+                                        @RequestParam(name = "annotationVepCacheversion", required = false) String annotationVepCacheversion,
                                         HttpServletResponse response)
             throws IOException {
         initializeQuery();
@@ -86,7 +88,8 @@ public class VariantWSServer extends EvaWSServer {
             numTotalResults = (long) variantEntities.size();
         } else {
             List<VariantRepositoryFilter> filters = new FilterBuilder()
-                    .getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies, consequenceType);
+                    .getVariantEntityRepositoryFilters(maf, polyphenScore, siftScore, studies, consequenceType,
+                                                       annotationVepVersion, annotationVepCacheversion);
 
             List<String> excludeMapped = new ArrayList<>();
             if (exclude != null && !exclude.isEmpty()) {

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHBeaconWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHBeaconWSServer.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.eva.commons.core.models.VariantType;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.utils.DBAdaptorConnector;
 import uk.ac.ebi.eva.lib.utils.MultiMongoDbFactory;
@@ -67,13 +67,12 @@ public class GA4GHBeaconWSServer extends EvaWSServer {
 
         MultiMongoDbFactory.setDatabaseNameForCurrentThread(DBAdaptorConnector.getDBName("hsapiens_grch37"));
 
-        List<VariantWithSamplesAndAnnotations> variantEntities;
+        List<VariantWithSamplesAndAnnotation> variantEntities;
         if (allele.equalsIgnoreCase("INDEL")) {
             variantEntities = service.findByChromosomeAndStartAndTypeAndStudyIn(chromosome, start, VariantType.INDEL,
-                                                                                                studies);
+                                                                                studies, null);
         } else {
-            variantEntities = service.findByChromosomeAndStartAndAltAndStudyIn(chromosome, start,
-                                                                                               allele, studies);
+            variantEntities = service.findByChromosomeAndStartAndAltAndStudyIn(chromosome, start, allele, studies, null);
         }
 
         return new GA4GHBeaconResponse(chromosome, start, allele, String.join(",", studies),

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHBeaconWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHBeaconWSServer.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.eva.commons.core.models.VariantType;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
+import uk.ac.ebi.eva.commons.mongodb.services.AnnotationMetadataNotFoundException;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.utils.DBAdaptorConnector;
 import uk.ac.ebi.eva.lib.utils.MultiMongoDbFactory;
@@ -55,8 +56,8 @@ public class GA4GHBeaconWSServer extends EvaWSServer {
                                       @RequestParam("start") int start,
                                       @RequestParam("allele") String allele,
                                       @RequestParam("datasetIds") List<String> studies,
-                                      HttpServletResponse response) 
-            throws IOException {
+                                      HttpServletResponse response)
+            throws IOException, AnnotationMetadataNotFoundException {
         initializeQuery();
 
         if (start < 0) {

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHVariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHVariantWSServer.java
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.eva.commons.core.models.Region;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.filter.FilterBuilder;
 import uk.ac.ebi.eva.commons.mongodb.filter.VariantRepositoryFilter;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
@@ -93,9 +93,10 @@ public class GA4GHVariantWSServer extends EvaWSServer {
         List<Region> regions = new ArrayList<>();
         regions.add(region);
 
-        List<VariantWithSamplesAndAnnotations> variantEntities = service.findByRegionsAndComplexFilters(regions, filters,
-                null, pageRequest);
-        List<VariantWithSamplesAndAnnotations> variants = Collections.unmodifiableList(variantEntities);
+        List<VariantWithSamplesAndAnnotation> variantEntities = service.findByRegionsAndComplexFilters(regions, filters,
+                                                                                                       null, null,
+                                                                                                       pageRequest);
+        List<VariantWithSamplesAndAnnotation> variants = Collections.unmodifiableList(variantEntities);
 
         Long numTotalResults = service.countByRegionsAndComplexFilters(regions, filters);
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHVariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHVariantWSServer.java
@@ -33,6 +33,7 @@ import uk.ac.ebi.eva.commons.core.models.Region;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.filter.FilterBuilder;
 import uk.ac.ebi.eva.commons.mongodb.filter.VariantRepositoryFilter;
+import uk.ac.ebi.eva.commons.mongodb.services.AnnotationMetadataNotFoundException;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.models.ga4gh.GASearchVariantRequest;
 import uk.ac.ebi.eva.lib.models.ga4gh.GASearchVariantsResponse;
@@ -77,7 +78,7 @@ public class GA4GHVariantWSServer extends EvaWSServer {
 //                                        @RequestParam(name = "callSetIds", required = false) String samples,
                                                         @RequestParam(name = "pageToken", required = false) String pageToken,
                                                         @RequestParam(name = "pageSize", defaultValue = "10") int limit)
-            throws UnknownHostException, IOException {
+            throws UnknownHostException, IOException, AnnotationMetadataNotFoundException {
         initializeQuery();
 
         MultiMongoDbFactory.setDatabaseNameForCurrentThread(DBAdaptorConnector.getDBName("hsapiens_grch37"));
@@ -111,7 +112,7 @@ public class GA4GHVariantWSServer extends EvaWSServer {
 
     @RequestMapping(value = "/search", method = RequestMethod.POST, consumes = "application/json")
     public GASearchVariantsResponse getVariantsByRegion(GASearchVariantRequest request)
-            throws UnknownHostException, IOException {
+            throws UnknownHostException, IOException, AnnotationMetadataNotFoundException {
         request.validate();
         return getVariantsByRegion(request.getReferenceName(), (int) request.getStart(), (int) request.getEnd(),
                 request.getVariantSetIds(), request.getPageToken(), request.getPageSize());

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/GeneWSServerTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/GeneWSServerTest.java
@@ -30,7 +30,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.eva.commons.core.models.Annotation;
 import uk.ac.ebi.eva.commons.core.models.Xref;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.utils.QueryResponse;
 import uk.ac.ebi.eva.lib.utils.QueryResult;
@@ -55,7 +55,7 @@ public class GeneWSServerTest {
     private VariantWithSamplesAndAnnotationsService service;
 
     private String GENE_ID = "GeneId";
-    private VariantWithSamplesAndAnnotations testVariantEntity;
+    private VariantWithSamplesAndAnnotation testVariantEntity;
 
     @Before
     public void setUp() throws Exception {
@@ -66,27 +66,26 @@ public class GeneWSServerTest {
         String alternate = "T";
         String vepVersion = "88";
         String vepCacheVersion = "89";
-        testVariantEntity = new VariantWithSamplesAndAnnotations(chromosome, start, end, reference, alternate);
+        testVariantEntity = new VariantWithSamplesAndAnnotation(chromosome, start, end, reference, alternate);
         Annotation variantAnnotation = new Annotation(chromosome, start, end, vepVersion, vepCacheVersion, Collections
                 .singleton(new Xref(GENE_ID, "HGNC")), null);
-        testVariantEntity.addAnnotation(variantAnnotation);
-        List<VariantWithSamplesAndAnnotations> variantEntities = Collections.singletonList(testVariantEntity);
+        testVariantEntity.setAnnotation(variantAnnotation);
+        List<VariantWithSamplesAndAnnotation> variantEntities = Collections.singletonList(testVariantEntity);
 
         List<String> geneIds = new ArrayList<>();
         geneIds.add(GENE_ID);
 
-        given(service.findByGenesAndComplexFilters(eq(geneIds), any(), any(), any()
-        )).willReturn(variantEntities);
+        given(service.findByGenesAndComplexFilters(eq(geneIds), any(), any(), any(), any())).willReturn(variantEntities);
         given(service.countByGenesAndComplexFilters(eq(geneIds), any())).willReturn(1L);
     }
 
     @Test
     public void testGetVariantByGeneExisting() {
-        QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>> queryResponse =
+        QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>> queryResponse =
                 testGetVariantByGeneHelper(Collections.singletonList(GENE_ID));
         assertEquals(1, queryResponse.getResponse().size());
 
-        List<VariantWithSamplesAndAnnotations> results = queryResponse.getResponse().get(0).getResult();
+        List<VariantWithSamplesAndAnnotation> results = queryResponse.getResponse().get(0).getResult();
 
         assertEquals(1, results.size());
         assertEquals(testVariantEntity, results.get(0));
@@ -94,21 +93,21 @@ public class GeneWSServerTest {
 
     @Test
     public void testGetVariantByGeneNotExisting() {
-        QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>> queryResponse =
+        QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>> queryResponse =
                 testGetVariantByGeneHelper(Collections.singletonList("not_a_real_id"));
         assertEquals(1, queryResponse.getResponse().size());
 
-        List<VariantWithSamplesAndAnnotations> results = queryResponse.getResponse().get(0).getResult();
+        List<VariantWithSamplesAndAnnotation> results = queryResponse.getResponse().get(0).getResult();
 
         assertEquals(0, results.size());
     }
 
-    private QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>> testGetVariantByGeneHelper(List<String> geneIds) {
+    private QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>> testGetVariantByGeneHelper(List<String> geneIds) {
         String url = "/v1/genes/" + String.join(",", geneIds) + "/variants?species=mmusculus_grcm38";
         String responseStr = restTemplate.getForObject(url,String.class);
-        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>> response = restTemplate.exchange(
+        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>> response = restTemplate.exchange(
                 url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>>() {
+                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>>() {
                 });
         assertEquals(HttpStatus.OK, response.getStatusCode());
 

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
@@ -61,7 +61,9 @@ import static org.junit.Assert.assertTrue;
 @Import(MongoRepositoryTestConfiguration.class)
 @UsingDataSet(locations = {
         "/test-data/variants.json",
-        "/test-data/files.json"
+        "/test-data/files.json",
+        "/test-data/annotations.json",
+        "/test-data/annotation_metadata.json"
 })
 @ActiveProfiles(Profiles.TEST_MONGO_FACTORY)
 public class RegionWSServerIntegrationTest {

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
@@ -149,8 +149,8 @@ public class RegionWSServerIntegrationTest {
         String annotationVepVersion = "78";
         String annotationVepCacheversion = "78";
         String url = "/v1/segments/" + testRegion +
-                "/variants?species=mmusculus_grcm38&annotation-vep-version=" + annotationVepVersion +
-                "&annotation-vep-cache-version=" + annotationVepCacheversion;
+                "/variants?species=mmusculus_grcm38&annot-vep-version=" + annotationVepVersion +
+                "&annot-vep-cache-version=" + annotationVepCacheversion;
         List<VariantWithSamplesAndAnnotation> variants = testRestTemplateHelper(url);
         for (VariantWithSamplesAndAnnotation variant : variants) {
             Annotation annotation = variant.getAnnotation();

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
@@ -37,8 +37,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import uk.ac.ebi.eva.commons.core.models.Annotation;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantSourceEntryWithSampleNames;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.Profiles;
 import uk.ac.ebi.eva.lib.utils.QueryResponse;
@@ -47,11 +48,12 @@ import uk.ac.ebi.eva.server.configuration.MongoRepositoryTestConfiguration;
 
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Set;
 
 import static com.lordofthejars.nosqlunit.mongodb.MongoDbRule.MongoDbRuleBuilder.newMongoDbRule;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
@@ -102,10 +104,10 @@ public class RegionWSServerIntegrationTest {
     }
 
     private void testGetVariantsByRegionHelper(String testRegion, int expectedVariants) throws URISyntaxException {
-        List<VariantWithSamplesAndAnnotations> results = regionWsHelper(testRegion);
+        List<VariantWithSamplesAndAnnotation> results = regionWsHelper(testRegion);
         assertEquals(expectedVariants, results.size());
 
-        for (VariantWithSamplesAndAnnotations variantEntity : results) {
+        for (VariantWithSamplesAndAnnotation variantEntity : results) {
             assertFalse(variantEntity.getChromosome().isEmpty());
             assertFalse(variantEntity.getReference().isEmpty());
             assertFalse(variantEntity.getAlternate().isEmpty());
@@ -117,41 +119,51 @@ public class RegionWSServerIntegrationTest {
         }
     }
 
-    private List<VariantWithSamplesAndAnnotations> regionWsHelper(String testRegion) {
+    private List<VariantWithSamplesAndAnnotation> regionWsHelper(String testRegion) {
         String url = "/v1/segments/" + testRegion + "/variants?species=mmusculus_grcm38";
-        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>> response = restTemplate.exchange(
-                url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>>() {
-                });
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-
-        QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>> queryResponse = response.getBody();
-        assertEquals(1, queryResponse.getResponse().size());
-
-        return queryResponse.getResponse().get(0).getResult();
+        return testRestTemplateHelper(url);
     }
 
     @Test
     public void testExcludeSourceEntriesStatistics() {
         String testRegion = "20:60099-60102";
         String testExclusion = "sourceEntries.statistics";
-        List<VariantWithSamplesAndAnnotations> results = testExcludeHelper(testRegion, testExclusion);
-        for (VariantWithSamplesAndAnnotations variant : results) {
+        List<VariantWithSamplesAndAnnotation> results = testExcludeHelper(testRegion, testExclusion);
+        for (VariantWithSamplesAndAnnotation variant : results) {
             for (VariantSourceEntryWithSampleNames sourceEntry : variant.getSourceEntries()) {
                 assertTrue(sourceEntry.getCohortStats().isEmpty());
             }
         }
     }
 
-    private List<VariantWithSamplesAndAnnotations> testExcludeHelper(String testRegion, String testExclusion) {
+    private List<VariantWithSamplesAndAnnotation> testExcludeHelper(String testRegion, String testExclusion) {
         String url = "/v1/segments/" + testRegion + "/variants?species=mmusculus_grcm38&exclude=" + testExclusion;
-        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>> response = restTemplate.exchange(
+        return testRestTemplateHelper(url);
+    }
+
+//    @Test
+//    public void testVepVersionAndVepCacheVersionFilter() {
+//        String testRegion = "20:60000-62000";
+//        String annotationVepVersion = "78";
+//        String url = "/v1/segments/" + testRegion + "/variants?species=mmusculus_grcm38&annotationVepVersion=" + annotationVepVersion;
+//        List<VariantWithSamplesAndAnnotation> variants = testRestTemplateHelper(url);
+//        for (VariantWithSamplesAndAnnotation variant : variants) {
+//            Set<Annotation> annotations = variant.getAnnotation();
+//            assertEquals(2, annotations.size());
+//            for (Annotation annotation : annotations) {
+//                assertEquals(annotationVepVersion, annotation.getVepVersion());
+//            }
+//        }
+//    }
+
+    private List<VariantWithSamplesAndAnnotation> testRestTemplateHelper(String url) {
+        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>> response = restTemplate.exchange(
                 url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>>() {
+                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>>() {
                 });
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
-        QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>> queryResponse = response.getBody();
+        QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>> queryResponse = response.getBody();
         assertEquals(1, queryResponse.getResponse().size());
 
         return queryResponse.getResponse().get(0).getResult();

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
@@ -149,8 +149,8 @@ public class RegionWSServerIntegrationTest {
         String annotationVepVersion = "78";
         String annotationVepCacheversion = "78";
         String url = "/v1/segments/" + testRegion +
-                "/variants?species=mmusculus_grcm38&annotationVepVersion=" + annotationVepVersion +
-                "&annotationVepCacheversion=" + annotationVepCacheversion;
+                "/variants?species=mmusculus_grcm38&annotation-vep-version=" + annotationVepVersion +
+                "&annotation-vep-cache-version=" + annotationVepCacheversion;
         List<VariantWithSamplesAndAnnotation> variants = testRestTemplateHelper(url);
         for (VariantWithSamplesAndAnnotation variant : variants) {
             Annotation annotation = variant.getAnnotation();

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerIntegrationTest.java
@@ -143,20 +143,21 @@ public class RegionWSServerIntegrationTest {
         return testRestTemplateHelper(url);
     }
 
-//    @Test
-//    public void testVepVersionAndVepCacheVersionFilter() {
-//        String testRegion = "20:60000-62000";
-//        String annotationVepVersion = "78";
-//        String url = "/v1/segments/" + testRegion + "/variants?species=mmusculus_grcm38&annotationVepVersion=" + annotationVepVersion;
-//        List<VariantWithSamplesAndAnnotation> variants = testRestTemplateHelper(url);
-//        for (VariantWithSamplesAndAnnotation variant : variants) {
-//            Set<Annotation> annotations = variant.getAnnotation();
-//            assertEquals(2, annotations.size());
-//            for (Annotation annotation : annotations) {
-//                assertEquals(annotationVepVersion, annotation.getVepVersion());
-//            }
-//        }
-//    }
+    @Test
+    public void testVepVersionAndVepCacheVersionFilter() {
+        String testRegion = "20:60000-62000";
+        String annotationVepVersion = "78";
+        String annotationVepCacheversion = "78";
+        String url = "/v1/segments/" + testRegion +
+                "/variants?species=mmusculus_grcm38&annotationVepVersion=" + annotationVepVersion +
+                "&annotationVepCacheversion=" + annotationVepCacheversion;
+        List<VariantWithSamplesAndAnnotation> variants = testRestTemplateHelper(url);
+        for (VariantWithSamplesAndAnnotation variant : variants) {
+            Annotation annotation = variant.getAnnotation();
+            assertEquals(annotationVepVersion, annotation.getVepVersion());
+            assertEquals(annotationVepCacheversion, annotation.getVepCacheVersion());
+        }
+    }
 
     private List<VariantWithSamplesAndAnnotation> testRestTemplateHelper(String url) {
         ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>> response = restTemplate.exchange(

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/RegionWSServerTest.java
@@ -31,7 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.eva.commons.core.models.Region;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.utils.QueryResponse;
 import uk.ac.ebi.eva.lib.utils.QueryResult;
@@ -62,21 +62,21 @@ public class RegionWSServerTest {
 
     @Before
     public void setUp() throws Exception {
-        VariantWithSamplesAndAnnotations variantEntity = new VariantWithSamplesAndAnnotations("chr1", 1000, 1005, "reference", "alternate");
+        VariantWithSamplesAndAnnotation variantEntity = new VariantWithSamplesAndAnnotation("chr1", 1000, 1005, "reference", "alternate");
 
         List<Region> oneRegion = Arrays.asList(
                 new Region("20", 60000, 62000));
-        given(service.findByRegionsAndComplexFilters(eq(oneRegion), any(), any(), any()))
+        given(service.findByRegionsAndComplexFilters(eq(oneRegion), any(), any(), any(), any()))
                 .willReturn(Collections.singletonList(variantEntity));
 
         List<Region> twoRegions = Arrays.asList(
                 new Region("20", 60000, 61000),
                 new Region("20", 61500, 62500));
-        given(service.findByRegionsAndComplexFilters(eq(twoRegions), any(), any(), any()))
+        given(service.findByRegionsAndComplexFilters(eq(twoRegions), any(), any(), any(), any()))
                 .willReturn(Arrays.asList(variantEntity, variantEntity));
 
         given(service
-                .findByRegionsAndComplexFilters(not(or(eq(oneRegion), eq(twoRegions))), any(), any(), any()))
+                .findByRegionsAndComplexFilters(not(or(eq(oneRegion), eq(twoRegions))), any(), any(), any(), any()))
                 .willReturn(Collections.emptyList());
     }
 
@@ -96,10 +96,10 @@ public class RegionWSServerTest {
     }
 
     private void testGetVariantsByRegionHelper(String testRegion, int expectedVariants) throws URISyntaxException {
-        List<VariantWithSamplesAndAnnotations> results = regionWsHelper(testRegion);
+        List<VariantWithSamplesAndAnnotation> results = regionWsHelper(testRegion);
         assertEquals(expectedVariants, results.size());
 
-        for (VariantWithSamplesAndAnnotations variantEntity : results) {
+        for (VariantWithSamplesAndAnnotation variantEntity : results) {
             assertFalse(variantEntity.getChromosome().isEmpty());
             assertFalse(variantEntity.getReference().isEmpty());
             assertFalse(variantEntity.getAlternate().isEmpty());
@@ -108,15 +108,15 @@ public class RegionWSServerTest {
         }
     }
 
-    private List<VariantWithSamplesAndAnnotations> regionWsHelper(String testRegion) {
+    private List<VariantWithSamplesAndAnnotation> regionWsHelper(String testRegion) {
         String url = "/v1/segments/" + testRegion + "/variants?species=mmusculus_grcm38";
-        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>> response = restTemplate.exchange(
+        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>> response = restTemplate.exchange(
                 url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>>() {
+                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>>() {
                 });
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
-        QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>> queryResponse = response.getBody();
+        QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>> queryResponse = response.getBody();
         assertEquals(1, queryResponse.getResponse().size());
 
         return queryResponse.getResponse().get(0).getResult();

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/VariantWSServerTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/VariantWSServerTest.java
@@ -31,7 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.eva.commons.core.models.Region;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.utils.QueryResponse;
 import uk.ac.ebi.eva.lib.utils.QueryResult;
@@ -63,7 +63,7 @@ public class VariantWSServerTest {
 
     private static final String NON_EXISTING_CHROMOSOME = "notARealChromosome";
 
-    private static final VariantWithSamplesAndAnnotations VARIANT = new VariantWithSamplesAndAnnotations("1", 1000, 1005, "A", "T");
+    private static final VariantWithSamplesAndAnnotation VARIANT = new VariantWithSamplesAndAnnotation("1", 1000, 1005, "A", "T");
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -73,13 +73,13 @@ public class VariantWSServerTest {
 
     @Before
     public void setUp() throws Exception {
-        List<VariantWithSamplesAndAnnotations> variantEntities = Collections.singletonList(VARIANT);
+        List<VariantWithSamplesAndAnnotation> variantEntities = Collections.singletonList(VARIANT);
 
         given(variantEntityRepository
-                .findByChromosomeAndStartAndReferenceAndAlternate(eq(CHROMOSOME), anyInt(), any(), any()))
+                .findByChromosomeAndStartAndReferenceAndAlternate(eq(CHROMOSOME), anyInt(), any(), any(), any()))
                 .willReturn(variantEntities);
 
-        given(variantEntityRepository.findByIdsAndComplexFilters(eq(VARIANT_ID), any(), any(), any()))
+        given(variantEntityRepository.findByIdsAndComplexFilters(eq(VARIANT_ID), any(), any(), any(), any()))
                 .willReturn(variantEntities);
 
     }
@@ -96,16 +96,16 @@ public class VariantWSServerTest {
 
     private void testGetVariantByIdRegionHelper(String testString) {
         String url = "/v1/variants/" + testString + "/info?species=mmusculus_grcm38";
-        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>> response = restTemplate.exchange(
+        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>> response = restTemplate.exchange(
                 url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>>() {
+                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>>() {
                 });
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
-        QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>> queryResponse = response.getBody();
+        QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>> queryResponse = response.getBody();
         assertEquals(1, queryResponse.getResponse().size());
 
-        List<VariantWithSamplesAndAnnotations> results = queryResponse.getResponse().get(0).getResult();
+        List<VariantWithSamplesAndAnnotation> results = queryResponse.getResponse().get(0).getResult();
         assertEquals(1, results.size());
 
         assertEquals(VARIANT, results.get(0));
@@ -123,16 +123,16 @@ public class VariantWSServerTest {
 
     private void testGetVariantByIdRegionDoesntExistHelper(String testString) throws URISyntaxException {
         String url = "/v1/variants/" + testString + "/info?species=mmusculus_grcm38";
-        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>> response = restTemplate.exchange(
+        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>> response = restTemplate.exchange(
                 url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>>>() {
+                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>>() {
                 });
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
-        QueryResponse<QueryResult<VariantWithSamplesAndAnnotations>> queryResponse = response.getBody();
+        QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>> queryResponse = response.getBody();
         assertEquals(1, queryResponse.getResponse().size());
 
-        List<VariantWithSamplesAndAnnotations> results = queryResponse.getResponse().get(0).getResult();
+        List<VariantWithSamplesAndAnnotation> results = queryResponse.getResponse().get(0).getResult();
         assertEquals(0, results.size());
     }
 

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHBeaconWSServerTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHBeaconWSServerTest.java
@@ -28,7 +28,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 
 import java.util.ArrayList;
@@ -55,10 +55,10 @@ public class GA4GHBeaconWSServerTest {
 
     @Before
     public void setUp() throws Exception {
-        VariantWithSamplesAndAnnotations variant = new VariantWithSamplesAndAnnotations("1", 1000, 1005, "reference", "alternate");
-        List<VariantWithSamplesAndAnnotations> variantEntities = Collections.singletonList(variant);
+        VariantWithSamplesAndAnnotation variant = new VariantWithSamplesAndAnnotation("1", 1000, 1005, "reference", "alternate");
+        List<VariantWithSamplesAndAnnotation> variantEntities = Collections.singletonList(variant);
 
-        given(service.findByChromosomeAndStartAndAltAndStudyIn(eq("1"), anyInt(), any(), any()))
+        given(service.findByChromosomeAndStartAndAltAndStudyIn(eq("1"), anyInt(), any(), any(), any()))
                 .willReturn(variantEntities);
     }
 

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHVariantWSServerTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ga4gh/GA4GHVariantWSServerTest.java
@@ -31,7 +31,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import uk.ac.ebi.eva.commons.core.models.Region;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantSourceEntryWithSampleNames;
-import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotations;
+import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantWithSamplesAndAnnotationsService;
 import uk.ac.ebi.eva.lib.models.ga4gh.GASearchVariantsResponse;
 import uk.ac.ebi.eva.lib.models.ga4gh.GAVariantFactory;
@@ -49,7 +49,7 @@ import static org.mockito.Matchers.eq;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class GA4GHVariantWSServerTest {
 
-    private VariantWithSamplesAndAnnotations variant;
+    private VariantWithSamplesAndAnnotation variant;
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -59,18 +59,19 @@ public class GA4GHVariantWSServerTest {
 
     @Before
     public void setUp() throws Exception {
-        variant = new VariantWithSamplesAndAnnotations("1", 1000, 1005, "A", "C");
+        variant = new VariantWithSamplesAndAnnotation("1", 1000, 1005, "A", "C");
         variant.setIds(Collections.singleton("1_1000_A_C"));
         variant.addSourceEntry(new VariantSourceEntryWithSampleNames("FILE_ID", "STUDY_ID", null, null, null, null,
                 null));
-        List<VariantWithSamplesAndAnnotations> variantEntities = Collections.singletonList(variant);
+        List<VariantWithSamplesAndAnnotation> variantEntities = Collections.singletonList(variant);
 
         Region region = new Region("1", 500, 2000);
 
         given(variantEntityRepository.findByRegionsAndComplexFilters(eq(Collections.singletonList(region)),
-                any(),
-                any(),
-                any()))
+                                                                     any(),
+                                                                     any(),
+                                                                     any(),
+                                                                     any()))
                 .willReturn(variantEntities);
         given(variantEntityRepository.countByRegionsAndComplexFilters(eq(Collections.singletonList(region)),
                 any()))

--- a/eva-server/src/test/resources/test-data/annotation_metadata.json
+++ b/eva-server/src/test/resources/test-data/annotation_metadata.json
@@ -4,13 +4,13 @@
       "vepv": "77",
       "_id": "77_77",
       "cachev": "77",
-      "default_version": false
+      "is_default": false
     },
     {
       "vepv": "78",
       "_id": "78_78",
       "cachev": "78",
-      "default_version": true
+      "is_default": true
     }
   ]
 }

--- a/eva-server/src/test/resources/test-data/annotation_metadata.json
+++ b/eva-server/src/test/resources/test-data/annotation_metadata.json
@@ -1,0 +1,16 @@
+{
+  "testMetadata": [
+    {
+      "vepv": "77",
+      "_id": "77_77",
+      "cachev": "77",
+      "default_version": false
+    },
+    {
+      "vepv": "78",
+      "_id": "78_78",
+      "cachev": "78",
+      "default_version": true
+    }
+  ]
+}

--- a/eva-server/src/test/resources/test-data/annotations.json
+++ b/eva-server/src/test/resources/test-data/annotations.json
@@ -1,0 +1,415 @@
+{
+  "testAnnotations": [
+    {
+      "xrefs": [
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000481932"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000468321"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000356150"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000405430"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000463865"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000488044"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000415006"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000473104"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000471948"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000403712"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000479739"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000431160"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000403658"
+        },
+        {
+          "src": "HGNC",
+          "id": "SH3YL1"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000403657"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000451005"
+        },
+        {
+          "src": "ensemblGene",
+          "id": "ENSG00000035115"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000472012"
+        }
+      ],
+      "end": 60100,
+      "start": 60100,
+      "chr": "20",
+      "cachev": "78",
+      "_id": "20_60100_A_T_78_78",
+      "vepv": "78",
+      "ct": [
+        {
+          "enst": "ENST00000479739",
+          "codon": "-",
+          "bt": "nonsense_mediated_decay",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627,
+            1621
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000471948",
+          "codon": "-",
+          "bt": "retained_intron",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1632
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000431160",
+          "codon": "-",
+          "bt": "protein_coding",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1632
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000451005",
+          "codon": "-",
+          "bt": "protein_coding",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000356150",
+          "codon": "-",
+          "bt": "protein_coding",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000463865",
+          "codon": "-",
+          "bt": "processed_transcript",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627,
+            1619
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000488044",
+          "codon": "-",
+          "bt": "processed_transcript",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1632
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000403712",
+          "codon": "-",
+          "bt": "protein_coding",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000403657",
+          "codon": "-",
+          "bt": "protein_coding",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000473104",
+          "codon": "-",
+          "bt": "processed_transcript",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627,
+            1619
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000415006",
+          "codon": "-",
+          "bt": "protein_coding",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000405430",
+          "codon": "-",
+          "bt": "protein_coding",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000481932",
+          "codon": "-",
+          "bt": "protein_coding",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1632
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000472012",
+          "codon": "-",
+          "bt": "processed_transcript",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627,
+            1619
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000468321",
+          "codon": "-",
+          "bt": "processed_transcript",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627,
+            1619
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000403658",
+          "codon": "-",
+          "bt": "protein_coding",
+          "ensg": "ENSG00000035115",
+          "so": [
+            1627
+          ],
+          "aaChange": "-",
+          "gn": "SH3YL1",
+          "strand": "-"
+        }
+      ]
+    },
+    {
+      "xrefs": [
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000421620"
+        },
+        {
+          "src": "HGNC",
+          "id": "XXyac-YRM2039.2"
+        },
+        {
+          "src": "ensemblGene",
+          "id": "ENSG00000181404"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000426146"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000442926"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000330546"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000442898"
+        },
+        {
+          "src": "ensemblGene",
+          "id": "ENSG00000236875"
+        },
+        {
+          "src": "HGNC",
+          "id": "DDX11L5"
+        },
+        {
+          "src": "ensemblTranscript",
+          "id": "ENST00000399972"
+        }
+      ],
+      "end": 62300,
+      "start": 62300,
+      "chr": "20",
+      "cachev": "78",
+      "_id": "20_62300_C_G_78_78",
+      "vepv": "78",
+      "ct": [
+        {
+          "enst": "ENST00000399972",
+          "codon": "-",
+          "bt": "unprocessed_pseudogene",
+          "ensg": "ENSG00000181404",
+          "so": [
+            1632
+          ],
+          "aaChange": "-",
+          "gn": "XXyac-YRM2039.2",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000421620",
+          "codon": "-",
+          "bt": "unprocessed_pseudogene",
+          "ensg": "ENSG00000236875",
+          "so": [
+            1631
+          ],
+          "aaChange": "-",
+          "gn": "DDX11L5",
+          "strand": "+"
+        },
+        {
+          "enst": "ENST00000330546",
+          "codon": "-",
+          "bt": "unprocessed_pseudogene",
+          "ensg": "ENSG00000181404",
+          "so": [
+            1632
+          ],
+          "aaChange": "-",
+          "gn": "XXyac-YRM2039.2",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000442898",
+          "codon": "-",
+          "bt": "unprocessed_pseudogene",
+          "ensg": "ENSG00000181404",
+          "so": [
+            1632
+          ],
+          "aaChange": "-",
+          "gn": "XXyac-YRM2039.2",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000442926",
+          "codon": "-",
+          "bt": "unprocessed_pseudogene",
+          "ensg": "ENSG00000181404",
+          "so": [
+            1632
+          ],
+          "aaChange": "-",
+          "gn": "XXyac-YRM2039.2",
+          "strand": "-"
+        },
+        {
+          "enst": "ENST00000426146",
+          "codon": "-",
+          "bt": "unprocessed_pseudogene",
+          "ensg": "ENSG00000236875",
+          "so": [
+            1631
+          ],
+          "aaChange": "-",
+          "gn": "DDX11L5",
+          "strand": "+"
+        },
+        {
+          "bt": "regulatory_region",
+          "so": [
+            1566
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
                 <artifactId>variation-commons</artifactId>
-                <version>0.3-SNAPSHOT</version>
+                <version>0.4-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>


### PR DESCRIPTION
- Use of new VariantWithSamplesAndAnnotation model
- Allows filtering by vep and vep cache version
- Requires PR in variation-commons to be deployed: https://github.com/EBIvariation/variation-commons/pull/39