### PR TITLE
EVA-820 SO name is not displayed for consequence types

### DIFF
--- a/eva-lib/pom.xml
+++ b/eva-lib/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.1</version>
+            <version>2.8.4</version>
         </dependency>
     </dependencies>
     

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/ConsequenceTypeMixin.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/ConsequenceTypeMixin.java
@@ -16,9 +16,9 @@
 
 package uk.ac.ebi.eva.lib.json;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 import java.util.Set;
 

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/ConsequenceTypeMixin.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/ConsequenceTypeMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.ebi.eva.lib.json;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.util.Set;
+
+public abstract class ConsequenceTypeMixin {
+
+    @JsonSerialize(using = SoTermsSerializer.class)
+    @JsonProperty("soTerms")
+    abstract public Set<Integer> getSoAccessions();
+
+    @JsonDeserialize(using = SoTermsDeserializer.class)
+    @JsonProperty("soTerms")
+    abstract public void setSoAccessions();
+}

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/ConsequenceTypeMixin.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/ConsequenceTypeMixin.java
@@ -30,5 +30,5 @@ public abstract class ConsequenceTypeMixin {
 
     @JsonDeserialize(using = SoTermsDeserializer.class)
     @JsonProperty("soTerms")
-    abstract public void setSoAccessions();
+    private Set<Integer> soAccessions;
 }

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/SoTermsDeserializer.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/SoTermsDeserializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.ebi.eva.lib.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SoTermsDeserializer extends StdDeserializer<Set<Integer>> {
+
+    protected SoTermsDeserializer() {
+        super(Set.class);
+    }
+
+    @Override
+    public Set<Integer> deserialize(JsonParser parser, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        JsonNode node = parser.getCodec().readTree(parser);
+        Set<Integer> soAccessions = new HashSet<>();
+        for (JsonNode element : node) {
+            String accession = element.get("soAccession").asText();
+            String[] code = accession.split(":");
+            Assert.isTrue(code.length == 2);
+            soAccessions.add(Integer.parseInt(code[1]));
+        }
+        return soAccessions;
+    }
+}

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/SoTermsSerializer.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/SoTermsSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.ebi.eva.lib.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import uk.ac.ebi.eva.lib.utils.ConsequenceTypeMappings;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class SoTermsSerializer extends StdSerializer<Set<Integer>> {
+
+    protected SoTermsSerializer() {
+        super(Set.class, true);
+    }
+
+    @Override
+    public void serialize(Set<Integer> integers, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+        jsonGenerator.writeStartArray();
+        for (Integer soAccession : integers) {
+            jsonGenerator.writeStartObject();
+            String soName = ConsequenceTypeMappings.accessionToTerm.get(soAccession);
+            jsonGenerator.writeStringField("soName", soName);
+            jsonGenerator.writeStringField("soAccession", ConsequenceTypeMappings.getSoAccessionString(soName));
+            jsonGenerator.writeEndObject();
+        }
+        jsonGenerator.writeEndArray();
+    }
+}

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/ConsequenceTypeMappings.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/ConsequenceTypeMappings.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.lib.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * TODO Handle duplicated terms in termToAccession (synonymous_variant...)
+ * TODO Load using ontology file: http://song.cvs.sourceforge.net/viewvc/song/ontology/so.obo
+ */
+public class ConsequenceTypeMappings {
+
+    public static final Map<String, Integer> termToAccession = new HashMap<>();
+
+    public static final Map<Integer, String> accessionToTerm = new HashMap<>();
+
+    static {
+        // Fill the term to accession map
+        termToAccession.put("transcript_ablation", 1893);
+        termToAccession.put("splice_donor_variant", 1575);
+        termToAccession.put("splice_acceptor_variant", 1574);
+        termToAccession.put("stop_gained", 1587);
+        termToAccession.put("frameshift_variant", 1589);
+        termToAccession.put("stop_lost", 1578);
+        termToAccession.put("initiator_codon_variant", 1582);
+        termToAccession.put("inframe_insertion", 1821);
+        termToAccession.put("inframe_deletion", 1822);
+        termToAccession.put("missense_variant", 1583);
+        termToAccession.put("transcript_amplification", 1889);
+        termToAccession.put("splice_region_variant", 1630);
+        termToAccession.put("incomplete_terminal_codon_variant", 1626);
+        termToAccession.put("synonymous_variant", 1819);
+        termToAccession.put("stop_retained_variant", 1567);
+        termToAccession.put("coding_sequence_variant", 1580);
+        termToAccession.put("miRNA", 276);
+        termToAccession.put("miRNA_target_site", 934);
+        termToAccession.put("mature_miRNA_variant", 1620);
+        termToAccession.put("5_prime_UTR_variant", 1623);
+        termToAccession.put("3_prime_UTR_variant", 1624);
+        termToAccession.put("exon_variant", 1791);
+        termToAccession.put("non_coding_transcript_exon_variant", 1792);
+        termToAccession.put("non_coding_transcript_variant", 1619);
+        termToAccession.put("intron_variant", 1627);
+        termToAccession.put("NMD_transcript_variant", 1621);
+        termToAccession.put("TFBS_ablation", 1895);
+        termToAccession.put("TFBS_amplification", 1892);
+        termToAccession.put("TF_binding_site_variant", 1782);
+        termToAccession.put("regulatory_region_variant", 1566);
+        termToAccession.put("regulatory_region_ablation", 1894);
+        termToAccession.put("regulatory_region_amplification", 1891);
+        termToAccession.put("feature_elongation", 1907);
+        termToAccession.put("feature_truncation", 1906);
+        termToAccession.put("intergenic_variant", 1628);
+        termToAccession.put("lincRNA", 1463);
+        termToAccession.put("downstream_gene_variant", 1632);
+        termToAccession.put("2KB_downstream_gene_variant", 1632);
+        termToAccession.put("upstream_gene_variant", 1631);
+        termToAccession.put("2KB_upstream_gene_variant", 1631);
+        termToAccession.put("SNV", 1483);
+        termToAccession.put("SNP", 694);
+        termToAccession.put("RNA_polymerase_promoter", 1203);
+        termToAccession.put("CpG_island", 307);
+        termToAccession.put("DNAseI_hypersensitive_site", 685);
+        termToAccession.put("polypeptide_variation_site", 336);
+        termToAccession.put("protein_altering_variant", 1818);
+        termToAccession.put("start_lost", 2012);
+
+        // Fill the accession to term map
+        for(String key : termToAccession.keySet()) {
+            accessionToTerm.put(termToAccession.get(key), key);
+        }
+    }
+
+    public static String getSoAccessionString(String SOName) {
+        if (termToAccession.get(SOName) == null) {
+            throw new SOTermNotAvailableException(SOName);
+        } else {
+            String soAccession = Integer.toString(termToAccession.get(SOName));
+            return String.format("SO:%0" + (7 - soAccession.length()) + "d%s", 0, soAccession);
+        }
+    }
+}

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/SOTermNotAvailableException.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/SOTermNotAvailableException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.ebi.eva.lib.utils;
 
 public class SOTermNotAvailableException extends RuntimeException {

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/SOTermNotAvailableException.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/SOTermNotAvailableException.java
@@ -1,0 +1,7 @@
+package uk.ac.ebi.eva.lib.utils;
+
+public class SOTermNotAvailableException extends RuntimeException {
+    public SOTermNotAvailableException(String soName) {
+        super("SO term " + soName + " not available in class ConsequenceTypeMappings");
+    }
+}

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/json/SoTermsDeserializerTest.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/json/SoTermsDeserializerTest.java
@@ -16,30 +16,29 @@
 
 package uk.ac.ebi.eva.lib.json;
 
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.junit.Test;
 
 import uk.ac.ebi.eva.commons.core.models.ConsequenceType;
 
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
 
-public class SoTermsSerializerTest {
+/**
+ * Created by jmmut on 2017-07-28.
+ *
+ * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ */
+public class SoTermsDeserializerTest {
     @Test
-    public void serialize() throws Exception {
+    public void deserialize() throws Exception {
         // given
-        HashSet<Integer> soAccessions = new HashSet<>(Arrays.asList(1578, 276));
-        ConsequenceType consequenceType = new ConsequenceType("", "", "", "", "", 0, 0, 0, "", "", null, null,
-                                                              soAccessions, 0);
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         objectMapper.addMixIn(ConsequenceType.class, ConsequenceTypeMixin.class);
@@ -50,19 +49,14 @@ public class SoTermsSerializerTest {
                                                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                                                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
 
-        StringWriter stringWriter = new StringWriter();
-        JsonGenerator generator = objectMapper.getFactory().createGenerator(stringWriter);
-
         // when
-        objectMapper.writeValue(generator, consequenceType);
+        ConsequenceType ct = objectMapper.readValue(
+                "{\"cDnaPosition\":0,\"cdsPosition\":0,\"aaPosition\":0,\"relativePosition\":0," +
+                        "\"soAccessions\":[{\"soName\":\"miRNA\",\"soAccession\":\"SO:0000276\"}," +
+                        "{\"soName\":\"stop_lost\",\"soAccession\":\"SO:0001578\"}]}", ConsequenceType.class);
 
         //then
-        JSONObject jsonObject = new JSONObject(stringWriter.getBuffer().toString());
-        JSONArray actual = jsonObject.getJSONArray("soTerms");
-
-        String expectedString = "[{\"soName\":\"miRNA\",\"soAccession\":\"SO:0000276\"},"
-                + "{\"soName\":\"stop_lost\",\"soAccession\":\"SO:0001578\"}]";
-        assertEquals(expectedString, actual.toString());
+        HashSet<Integer> expectedSoAccessions = new HashSet<>(Arrays.asList(1578, 276));
+        assertEquals(expectedSoAccessions, ct.getSoAccessions());
     }
-
 }

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/json/SoTermsDeserializerTest.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/json/SoTermsDeserializerTest.java
@@ -16,7 +16,6 @@
 
 package uk.ac.ebi.eva.lib.json;
 
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -30,11 +29,6 @@ import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * Created by jmmut on 2017-07-28.
- *
- * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
- */
 public class SoTermsDeserializerTest {
     @Test
     public void deserialize() throws Exception {

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/json/SoTermsDeserializerTest.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/json/SoTermsDeserializerTest.java
@@ -52,7 +52,7 @@ public class SoTermsDeserializerTest {
         // when
         ConsequenceType ct = objectMapper.readValue(
                 "{\"cDnaPosition\":0,\"cdsPosition\":0,\"aaPosition\":0,\"relativePosition\":0," +
-                        "\"soAccessions\":[{\"soName\":\"miRNA\",\"soAccession\":\"SO:0000276\"}," +
+                        "\"soTerms\":[{\"soName\":\"miRNA\",\"soAccession\":\"SO:0000276\"}," +
                         "{\"soName\":\"stop_lost\",\"soAccession\":\"SO:0001578\"}]}", ConsequenceType.class);
 
         //then

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/json/SoTermsSerializerTest.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/json/SoTermsSerializerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.ebi.eva.lib.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.util.JsonParserDelegate;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import uk.ac.ebi.eva.commons.core.models.ConsequenceType;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class SoTermsSerializerTest {
+    @Test
+    public void serialize() throws Exception {
+        // given
+        HashSet<Integer> soAccessions = new HashSet<>(Arrays.asList(1578, 276));
+        ConsequenceType consequenceType = new ConsequenceType("", "", "", "", "", 0, 0, 0, "", "", null, null,
+                                                              soAccessions, 0);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.addMixIn(ConsequenceType.class, ConsequenceTypeMixin.class);
+        StringWriter stringWriter = new StringWriter();
+        JsonGenerator generator = objectMapper.getFactory().createGenerator(stringWriter);
+
+        // when
+        objectMapper.writeValue(generator, consequenceType);
+
+        //then
+        JSONObject jsonObject = new JSONObject(stringWriter.getBuffer().toString());
+        JSONArray actual = jsonObject.getJSONArray("soAccessions");
+
+        String expectedString = "[{\"soName\":\"miRNA\",\"soAccession\":\"SO:0000276\"},"
+                + "{\"soName\":\"stop_lost\",\"soAccession\":\"SO:0001578\"}]";
+        assertEquals(expectedString, actual.toString());
+    }
+
+}

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/configuration/JacksonConfiguration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/configuration/JacksonConfiguration.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -46,12 +47,12 @@ public class JacksonConfiguration {
         objectMapper.addMixIn(VariantStatistics.class, VariantStatisticsMixin.class);
         objectMapper.addMixIn(ConsequenceType.class, ConsequenceTypeMixin.class);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
-                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
-                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
-                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
-                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE)
-        );
+        VisibilityChecker<?> vc = objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
+                                              .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                                              .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                                              .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                                              .withCreatorVisibility(JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(vc);
         return objectMapper;
     }
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/configuration/JacksonConfiguration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/configuration/JacksonConfiguration.java
@@ -22,8 +22,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import uk.ac.ebi.eva.commons.core.models.ConsequenceType;
 import uk.ac.ebi.eva.commons.core.models.VariantStatistics;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
+import uk.ac.ebi.eva.lib.json.ConsequenceTypeMixin;
 import uk.ac.ebi.eva.lib.json.QueryResponseMixin;
 import uk.ac.ebi.eva.lib.json.VariantMixin;
 import uk.ac.ebi.eva.lib.json.VariantStatisticsMixin;
@@ -42,6 +44,7 @@ public class JacksonConfiguration {
         objectMapper.addMixIn(QueryResponse.class, QueryResponseMixin.class);
         objectMapper.addMixIn(VariantStudy.class, VariantStudyMixin.class);
         objectMapper.addMixIn(VariantStatistics.class, VariantStatisticsMixin.class);
+        objectMapper.addMixIn(ConsequenceType.class, ConsequenceTypeMixin.class);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)


### PR DESCRIPTION
this is the structure for consequence types this PR achieves (taken from localhost swagger):

          "annotation": {
            "chromosome": "20",
            "start": 60343,
            "end": 60343,
            "vepVersion": "78",
            "vepCacheVersion": "78",
            "consequenceTypes": [
              {
                "soTerms": [
                  {
                    "soName": "intergenic_variant",
                    "soAccession": "SO:0001628"
                  }
                ]
              }
            ]
          }
