### PR TITLE
EVA-835 Prevent unnecessary DBMS driver dependencies from being exported

### DIFF
--- a/dgva-server/pom.xml
+++ b/dgva-server/pom.xml
@@ -13,6 +13,7 @@
     <packaging>war</packaging>
 
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -52,10 +53,16 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>eva-lib</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-data-mongodb</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
-            <artifactId>variation-commons</artifactId>
+            <artifactId>core</artifactId>
         </dependency>
 
         <dependency>

--- a/dgva-server/pom.xml
+++ b/dgva-server/pom.xml
@@ -62,7 +62,7 @@
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>variation-commons-core</artifactId>
         </dependency>
 
         <dependency>

--- a/dgva-server/src/test/java/uk/ac/ebi/dgva/server/ws/ArchiveWSServerTest.java
+++ b/dgva-server/src/test/java/uk/ac/ebi/dgva/server/ws/ArchiveWSServerTest.java
@@ -32,7 +32,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import uk.ac.ebi.eva.commons.core.models.StudyType;
-import uk.ac.ebi.eva.commons.mongodb.projections.VariantStudySummary;
 import uk.ac.ebi.eva.lib.metadata.dgva.ArchiveDgvaDBAdaptor;
 import uk.ac.ebi.eva.lib.metadata.dgva.StudyDgvaDBAdaptor;
 import uk.ac.ebi.eva.lib.models.VariantStudy;
@@ -103,16 +102,6 @@ public class ArchiveWSServerTest {
                                                                                              Collectors.counting()));
         given(archiveDgvaDBAdaptor.countStudiesPerType(anyObject()))
                 .willReturn(encapsulateInQueryResult(svStudiesGroupedByStudyType.entrySet().toArray()));
-    }
-
-    private List<VariantStudySummary> buildVariantStudySummaries() {
-        List<VariantStudySummary> studies = new ArrayList<>();
-        VariantStudySummary study = new VariantStudySummary();
-        study.setFilesCount(1);
-        study.setStudyId("studyId");
-        study.setStudyName("studyName");
-        studies.add(study);
-        return studies;
     }
 
     private <T> QueryResult<T> encapsulateInQueryResult(T... results) {

--- a/eva-lib/pom.xml
+++ b/eva-lib/pom.xml
@@ -18,7 +18,7 @@
     <dependencies>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
-            <artifactId>variation-commons</artifactId>
+            <artifactId>core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/eva-lib/pom.xml
+++ b/eva-lib/pom.xml
@@ -18,7 +18,7 @@
     <dependencies>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>variation-commons-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/eva_utils/EvaproDbUtils.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/eva_utils/EvaproDbUtils.java
@@ -17,6 +17,7 @@ package uk.ac.ebi.eva.lib.eva_utils;
 
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.Specifications;
+
 import uk.ac.ebi.eva.commons.core.models.StudyType;
 import uk.ac.ebi.eva.lib.extension.GenericSpecifications;
 import uk.ac.ebi.eva.lib.repositories.EvaStudyBrowserRepository;

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -49,8 +49,11 @@
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
-            <artifactId>variation-commons</artifactId>
-            <version>0.4-SNAPSHOT</version>
+            <artifactId>mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>core</artifactId>
         </dependency>
 
         <dependency>

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -49,11 +49,11 @@
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
-            <artifactId>mongodb</artifactId>
+            <artifactId>variation-commons-mongodb</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>variation-commons-core</artifactId>
         </dependency>
 
         <dependency>

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ArchiveWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ArchiveWSServer.java
@@ -22,6 +22,8 @@ package uk.ac.ebi.eva.server.ws;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.annotations.Api;
+
+import uk.ac.ebi.eva.commons.mongodb.entities.projections.VariantStudySummary;
 import uk.ac.ebi.eva.lib.utils.QueryResponse;
 import uk.ac.ebi.eva.lib.utils.QueryResult;
 import uk.ac.ebi.eva.lib.utils.QueryOptions;
@@ -30,7 +32,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import uk.ac.ebi.eva.commons.mongodb.projections.VariantStudySummary;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantStudySummaryService;
 import uk.ac.ebi.eva.lib.metadata.dgva.ArchiveDgvaDBAdaptor;
 import uk.ac.ebi.eva.lib.metadata.eva.ArchiveEvaproDBAdaptor;

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/RegionWSServer.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import uk.ac.ebi.eva.commons.core.models.Annotation;
 import uk.ac.ebi.eva.commons.core.models.AnnotationMetadata;
 import uk.ac.ebi.eva.commons.core.models.Region;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/StudyWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/StudyWSServer.java
@@ -26,7 +26,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import uk.ac.ebi.eva.commons.mongodb.projections.VariantStudySummary;
+
+import uk.ac.ebi.eva.commons.mongodb.entities.projections.VariantStudySummary;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantSourceService;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantStudySummaryService;
 import uk.ac.ebi.eva.lib.metadata.dgva.StudyDgvaDBAdaptor;

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ArchiveWSServerTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ArchiveWSServerTest.java
@@ -33,7 +33,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.eva.commons.core.models.StudyType;
-import uk.ac.ebi.eva.commons.mongodb.projections.VariantStudySummary;
+import uk.ac.ebi.eva.commons.mongodb.entities.projections.VariantStudySummary;
 import uk.ac.ebi.eva.commons.mongodb.services.VariantStudySummaryService;
 import uk.ac.ebi.eva.lib.metadata.dgva.ArchiveDgvaDBAdaptor;
 import uk.ac.ebi.eva.lib.metadata.eva.ArchiveEvaproDBAdaptor;

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,18 @@
             <!-- General dependencies -->
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
-                <artifactId>variation-commons</artifactId>
-                <version>0.4-SNAPSHOT</version>
+                <artifactId>core</artifactId>
+                <version>0.5-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>uk.ac.ebi.eva</groupId>
+                <artifactId>jpa</artifactId>
+                <version>0.5-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>uk.ac.ebi.eva</groupId>
+                <artifactId>mongodb</artifactId>
+                <version>0.5-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,17 +47,17 @@
             <!-- General dependencies -->
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
-                <artifactId>core</artifactId>
+                <artifactId>variation-commons-core</artifactId>
                 <version>0.5-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
-                <artifactId>jpa</artifactId>
+                <artifactId>variation-commons-jpa</artifactId>
                 <version>0.5-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
-                <artifactId>mongodb</artifactId>
+                <artifactId>variation-commons-mongodb</artifactId>
                 <version>0.5-SNAPSHOT</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Updated poms and imports to correspond with new variation-commons submodule structure.

The PR https://github.com/EBIvariation/variation-commons/pull/42 needs merging and deploying before this will build correctly.