### PR TITLE
EVA-837 Support databases with no VEP annotation

### DIFF
--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>variation-commons</artifactId>
-            <version>0.4</version>
+            <version>0.4.1</version>
         </dependency>
 
         <dependency>

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>variation-commons</artifactId>
-            <version>0.4-SNAPSHOT</version>
+            <version>0.4</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
                 <artifactId>variation-commons</artifactId>
-                <version>0.4-SNAPSHOT</version>
+                <version>0.4.1</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>


### PR DESCRIPTION
Use 0.4.1 version of variation-commons. Requires the PR https://github.com/EBIvariation/variation-commons/pull/43 to be merged and deployed.