### PR TITLE
DGVA-64 Study type name should not be ignored

### DIFF
--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/VariantStudyMixin.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/json/VariantStudyMixin.java
@@ -16,8 +16,11 @@
 
 package uk.ac.ebi.eva.lib.json;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties({"typeName"})
 public abstract class VariantStudyMixin {
+
+    @JsonProperty
+    public abstract String getTypeName();
+
 }

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ArchiveWSServerTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ArchiveWSServerTest.java
@@ -331,6 +331,7 @@ public class ArchiveWSServerTest {
             assertFalse(variantStudy.getCenter().isEmpty());
             assertFalse(variantStudy.getMaterial().isEmpty());
             assertFalse(variantStudy.getScope().isEmpty());
+            assertFalse(variantStudy.getTypeName().isEmpty());
             assertFalse(variantStudy.getExperimentType().isEmpty());
             assertFalse(variantStudy.getExperimentTypeAbbreviation().isEmpty());
             assertFalse(variantStudy.getAssembly().isEmpty());


### PR DESCRIPTION
Our default visibility policy is defined in a way that attributes are serialized, but getters are not. This is usually fine, but variant studies have a getter for user-friendly display of their type. This PR fixes the issue that prevented them from being returned in the response.

This issue does not affect the new DGVa web services yet, but when they are configured in the same way as the EVA ones it would.