### PR TITLE
EVA-879 Do not wrap collections in another collection when building response

### DIFF
--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/EvaWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/EvaWSServer.java
@@ -30,6 +30,7 @@ import uk.ac.ebi.eva.lib.utils.QueryResult;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,12 @@ public class EvaWSServer {
         queryOptions.put("limit", (limit > 0) ? limit : -1);
         queryOptions.put("skip", (skip > 0) ? skip : -1);
         queryOptions.put("count", count);
+    }
+
+    protected <T> QueryResponse<T> setQueryResponse(List<T> collection) {
+        QueryResponse<T> queryResponse = buildQueryResponse();
+        queryResponse.setResponse(collection);
+        return queryResponse;
     }
 
     protected <T> QueryResponse<T> setQueryResponse(T obj) {


### PR DESCRIPTION
The existing implementation of `setQueryResponse` wrapped anything that was returned in a collection. When the returned value is a collection itself this causes excessive nesting.