### PR TITLE
EVA-917 Bugfix for allele frequencies not correctly mapped from Mongo to JSON

### DIFF
--- a/eva-lib/pom.xml
+++ b/eva-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>eva</artifactId>
-        <version>1.5</version>
+        <version>1.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eva-server/pom.xml
+++ b/eva-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>eva</artifactId>
         <groupId>uk.ac.ebi.eva</groupId>
-        <version>1.5</version>
+        <version>1.5.1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>uk.ac.ebi.eva</groupId>
     <artifactId>eva</artifactId>
     <packaging>pom</packaging>
-    <version>1.5</version>
+    <version>1.5.1</version>
 
     <modules>
         <module>eva-lib</module>
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
                 <artifactId>variation-commons</artifactId>
-                <version>0.4.2</version>
+                <version>0.4.3</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>


### PR DESCRIPTION
By using variation-commons 0.4.3 (requires https://github.com/EBIvariation/variation-commons/pull/48), population statistics are no longer re-calculated after reading variants from the database.