### PR TITLE
EVA-812 Links to submitted and curated FTP in study view page

### DIFF
--- a/dgva-server/src/test/java/uk/ac/ebi/dgva/server/ws/ArchiveWSServerTest.java
+++ b/dgva-server/src/test/java/uk/ac/ebi/dgva/server/ws/ArchiveWSServerTest.java
@@ -43,7 +43,6 @@ import uk.ac.ebi.eva.lib.utils.QueryResult;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -79,17 +78,17 @@ public class ArchiveWSServerTest {
                                                  "Human", "Homo Sapiens", "Germline", "EBI", "DNA", "multi-isolate",
                                                  StudyType.CASE_CONTROL, "Exome Sequencing", "ES",
                                                  "GRCh37", "Illumina", new URI("http://www.s1.org"), new String[]{"10"},
-                                                 1000, 10);
+                                                 1000, 10, false);
         VariantStudy svStudy2 = new VariantStudy("Human SVV Test study 2", "svS2", null, "SV study 2 description",
                                                  new int[]{9606}, "Human", "Homo Sapiens", "Germline", "EBI", "DNA",
                                                  "multi-isolate", StudyType.AGGREGATE, "Exome Sequencing",
                                                  "ES", "GRCh38", "Illumina", new URI("http://www.s2.org"),
-                                                 new String[]{"13"}, 5000, 4);
+                                                 new String[]{"13"}, 5000, 4, false);
         VariantStudy svStudy3 = new VariantStudy("Cow SV Test study 1", "svCS1", null, "SV cow study 1 description",
                                                  new int[]{9913}, "Cow", "Bos taurus", "Germline", "EBI", "DNA",
                                                  "multi-isolate", StudyType.AGGREGATE,
                                                  "Whole Genome Sequencing", "WGSS", "Bos_taurus_UMD_3.1", "Illumina",
-                                                 new URI("http://www.cs1.org"), new String[]{"1", "2"}, 1300, 12);
+                                                 new URI("http://www.cs1.org"), new String[]{"1", "2"}, 1300, 12, false);
         given(studyDgvaDBAdaptor.getAllStudies(anyObject()))
                 .willReturn(encapsulateInQueryResult(svStudy1, svStudy2, svStudy3));
 

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/entities/DgvaStudyBrowser.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/entities/DgvaStudyBrowser.java
@@ -112,7 +112,7 @@ public class DgvaStudyBrowser {
                                               studyDescription, taxIds, commonName, scientificName,
                                               null, null, null, null, EvaproDbUtils.stringToStudyType(studyType), analysisType,
                                               null, assemblyName, platformName, uri, publications,
-                                              -1, -1);
+                                              -1, -1, false);
         return study;
     }
 }

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/entities/EvaStudyBrowser.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/entities/EvaStudyBrowser.java
@@ -88,12 +88,14 @@ public class EvaStudyBrowser {
 
     private String resource;
 
+    private boolean browsable;
+
     public EvaStudyBrowser(String projectAccession, long studyId, String projectTitle, String description,
                            String taxId, String commonName, String scientificName, String sourceType,
                            String studyType, Long variantCount, Integer samples, String center, String scope,
                            String material, String publications, String associatedProjects, String experimentType,
                            String experimentTypeAbbreviation, String assemblyAccession, String assemblyName,
-                           String platform, String resource) {
+                           String platform, String resource, boolean browsable) {
         this.projectAccession = projectAccession;
         this.studyId = studyId;
         this.projectTitle = projectTitle;
@@ -116,6 +118,7 @@ public class EvaStudyBrowser {
         this.assemblyName = assemblyName;
         this.platform = platform;
         this.resource = resource;
+        this.browsable = browsable;
     }
 
     EvaStudyBrowser() { }
@@ -139,6 +142,6 @@ public class EvaStudyBrowser {
                                 sourceType, center, material, scope,
                                 StudyType.fromString(studyType), experimentType,
                                 experimentTypeAbbreviation, assemblyName, platform,
-                                uri, publications.split(", "), notNullVariantCount, samples);
+                                uri, publications.split(", "), notNullVariantCount, samples, browsable);
     }
 }

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/models/VariantStudy.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/models/VariantStudy.java
@@ -67,6 +67,7 @@ public class VariantStudy {
 
     private List<VariantSourceEntryWithSampleNames> sources;
 
+    private boolean browsable;
 
     public VariantStudy() {
         this(null, null);
@@ -78,13 +79,16 @@ public class VariantStudy {
 
     public VariantStudy(String studyName, String studyId, List<VariantSourceEntryWithSampleNames> sources) {
         this(studyName, studyId, sources, null, new int[0], null, null, null, null, null, null, StudyType.COLLECTION,
-                null, null, null, null, null, new String[0], -1, -1);
+             null, null, null, null, null, new String[0], -1, -1, false);
     }
 
-    public VariantStudy(String studyName, String studyId, List<VariantSourceEntryWithSampleNames> sources, String description, int[] taxonomyId,
-                        String speciesCommonName, String speciesScientificName, String sourceType, String center, String material,
-                        String scope, StudyType type, String experimentType, String experimentTypeAbbreviation, String referenceAssembly,
-                        String platform, URI projectUrl, String[] publications, int numVariants, int numSamples) {
+    public VariantStudy(String studyName, String studyId, List<VariantSourceEntryWithSampleNames> sources,
+                        String description, int[] taxonomyId, String speciesCommonName, String speciesScientificName,
+                        String sourceType, String center, String material, String scope, StudyType type,
+                        String experimentType, String experimentTypeAbbreviation, String referenceAssembly,
+                        String platform, URI projectUrl, String[] publications, int numVariants, int numSamples,
+                        boolean browsable) {
+
         this.name = studyName;
         this.id = studyId;
         this.description = description;
@@ -105,6 +109,7 @@ public class VariantStudy {
         this.numVariants = numVariants;
         this.numSamples = numSamples;
         this.sources = sources;
+        this.browsable = browsable;
     }
 
     public String getName() {
@@ -273,5 +278,13 @@ public class VariantStudy {
 
     public boolean addSource(VariantSourceEntryWithSampleNames source) {
         return this.sources.add(source);
+    }
+
+    public boolean isBrowsable() {
+        return browsable;
+    }
+
+    public void setBrowsable(boolean browsable) {
+        this.browsable = browsable;
     }
 }

--- a/eva-lib/src/main/resources/study_browser.sql
+++ b/eva-lib/src/main/resources/study_browser.sql
@@ -1,0 +1,54 @@
+CREATE MATERIALIZED VIEW evapro.study_browser AS
+ SELECT project.project_accession,
+    project.eva_study_accession AS study_id,
+    project.title AS project_title,
+    COALESCE(project.eva_description, project.description) AS description,
+    COALESCE(project_children_taxonomy.taxonomy_ids, '-'::text) AS tax_id,
+    COALESCE(project_children_taxonomy.taxonomy_common_names, '-'::text) AS common_name,
+    COALESCE(project_children_taxonomy.taxonomy_scientific_names, '-'::text) AS scientific_name,
+    COALESCE(project.source_type, '-'::character varying) AS source_type,
+    COALESCE(project.study_type, '-'::character varying) AS study_type,
+    COALESCE(project_counts.etl_count, project_counts.estimate_count) AS variant_count,
+    project_samples_temp1.sample_count AS samples,
+    COALESCE(project.eva_center_name, project.center_name) AS center,
+    COALESCE(project.scope, '-'::character varying) AS scope,
+    COALESCE(project.material, '-'::character varying) AS material,
+    COALESCE(c.ids, '-'::text) AS publications,
+    COALESCE(project_children_taxonomy.child_projects, '-'::text) AS associated_projects,
+    COALESCE(initcap(project_experiment.experiment_type), '-'::text) AS experiment_type,
+    COALESCE(project_experiment.experiment_type_abbreviation, '-'::text) AS experiment_type_abbreviation,
+    COALESCE(a.v_ref, '-'::text) AS assembly_accession,
+    COALESCE(b.v_ref, '-'::text) AS assembly_name,
+    COALESCE(d.platform, '-'::text) AS platform,
+    COALESCE(r.resource, '-'::text::character varying) AS resource,
+    COALESCE(browsable_table.browsable, false) AS browsable
+   FROM project
+     LEFT JOIN project_counts USING (project_accession)
+     LEFT JOIN project_children_taxonomy USING (project_accession)
+     LEFT JOIN project_samples_temp1 USING (project_accession)
+     LEFT JOIN project_eva_submission project_eva_submission(project_accession, eva_submission_id, eload_id, old_eva_submission_id) USING (project_accession)
+     LEFT JOIN project_experiment USING (project_accession)
+     LEFT JOIN ( SELECT project_publication.project_accession,
+            string_agg(project_publication.id::text, ', '::text) AS ids
+           FROM project_publication
+          GROUP BY project_publication.project_accession) c(project_accession_1, ids) ON c.project_accession_1::text = project.project_accession::text
+     LEFT JOIN ( SELECT project_reference.project_accession,
+            string_agg(project_reference.reference_accession::text, ', '::text) AS v_ref
+           FROM project_reference
+          GROUP BY project_reference.project_accession) a(project_accession_1, v_ref) ON a.project_accession_1::text = project.project_accession::text
+     LEFT JOIN ( SELECT project_reference.project_accession,
+            string_agg(project_reference.reference_name::text, ', '::text) AS v_ref
+           FROM project_reference
+          GROUP BY project_reference.project_accession) b(project_accession_1, v_ref) ON b.project_accession_1::text = project.project_accession::text
+     LEFT JOIN ( SELECT project_platform.project_accession,
+            string_agg(project_platform.platform::text, ', '::text) AS platform
+           FROM project_platform
+          GROUP BY project_platform.project_accession) d(project_accession_1, platform) ON d.project_accession_1::text = project.project_accession::text
+     JOIN eva_submission USING (eva_submission_id)
+     LEFT JOIN project_resource r USING (project_accession)
+     LEFT JOIN ( SELECT browsable_file.project_accession,
+            true AS browsable
+           FROM browsable_file
+          GROUP BY browsable_file.project_accession) browsable_table(project_accession_browsable, browsable) ON browsable_table.project_accession_browsable::text = project.project_accession::text
+  WHERE (project.hold_date <= now()::date OR project.hold_date IS NULL) AND eva_submission.eva_submission_status_id >= 6 AND project.ena_status = 4 AND project.eva_status = 1
+  ORDER BY project_children_taxonomy.taxonomy_common_names;

--- a/eva-lib/src/test/java/uk/ac/ebi/eva/lib/metadata/eva/EvaStudyBrowserTestData.java
+++ b/eva-lib/src/test/java/uk/ac/ebi/eva/lib/metadata/eva/EvaStudyBrowserTestData.java
@@ -43,23 +43,23 @@ final class EvaStudyBrowserTestData {
                                                              "scope 1", "DNA", "PubMed:1111", "PRJ00002",
                                                              WHOLE_GENOME_SEQUENCING, "WGS", "GCA_000001405.22",
                                                              "GRCh38.p7",
-                                                             "Illumina", "Resource1");
+                                                             "Illumina", "Resource1", false);
         EvaStudyBrowser humanWGSStudy2 = new EvaStudyBrowser("PRJ0002", 2, "Project 2", "This is project 2", "2222",
                                                              HUMAN, HOMO_SAPIENS, "source 2",
                                                              "Whole genome sequencing", 2000000L, 2000, "center 2",
                                                              "scope 2", "DNA", "PubMed:2222", "PRJ00002",
                                                              RNA_SEQ, "WGS", "GCA_000001405.22", "GRCh38.p7",
-                                                             "Illumina", "Resource2");
+                                                             "Illumina", "Resource2", false);
         EvaStudyBrowser humanESStudy = new EvaStudyBrowser("PRJ0003", 3, "Project 3", "This is project 3", "3333",
                                                            HUMAN, HOMO_SAPIENS, "source 3", EXOME_SEQUENCING,
                                                            3000000L, 3000, "center 3", "scope 3", "DNA", "PubMed:3333",
                                                            "PRJ00003", EXOME_SEQUENCING, "ES", "GCA_000001405.14",
-                                                           "GRCh37.p13", "Illumina", "Resource3");
+                                                           "GRCh37.p13", "Illumina", "Resource3", false);
         EvaStudyBrowser cowESStudy = new EvaStudyBrowser("PRJ0004", 4, "Project 4", "This is project 4", "4444", CATTLE,
                                                          BOS_TAURUS, "source 4", EXOME_SEQUENCING, 4000000L, 4000,
                                                          "center 4", "scope 4", "DNA", "PubMed:4444", "PRJ00004",
                                                          EXOME_SEQUENCING, "ES", "GCA_000003055.3", "UMD3.1",
-                                                         "Illumina", "Resource4");
+                                                         "Illumina", "Resource4", false);
         entityManager.persist(humanWGSStudy1);
         entityManager.persist(humanWGSStudy2);
         entityManager.persist(humanESStudy);

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ArchiveWSServerTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ArchiveWSServerTest.java
@@ -109,16 +109,18 @@ public class ArchiveWSServerTest {
         VariantStudy study1 = new VariantStudy("Human Test study 1", "S1", null, "Study 1 description", new int[]{9606},
                                                "Human", "Homo Sapiens", "Germline", "EBI", "DNA", "multi-isolate",
                                                StudyType.CASE_CONTROL, "Exome Sequencing", "ES", "GRCh37",
-                                               "Illumina", new URI("http://www.s1.org"), new String[]{"10"}, 1000, 10);
+                                               "Illumina", new URI("http://www.s1.org"), new String[]{"10"}, 1000, 10,
+                                               false);
         VariantStudy study2 = new VariantStudy("Human Test study 2", "S2", null, "Study 2 description", new int[]{9606},
                                                "Human", "Homo Sapiens", "Germline", "EBI", "DNA", "multi-isolate",
                                                StudyType.AGGREGATE, "Exome Sequencing", "ES", "GRCh38",
-                                               "Illumina", new URI("http://www.s2.org"), new String[]{"13"}, 5000, 4);
+                                               "Illumina", new URI("http://www.s2.org"), new String[]{"13"}, 5000, 4,
+                                               false);
         VariantStudy study3 = new VariantStudy("Cow Test study 1", "CS1", null, "Cow study 1 description",
                                                new int[]{9913}, "Cow", "Bos taurus", "Germline", "EBI", "DNA",
                                                "multi-isolate", StudyType.AGGREGATE,
                                                "Whole Genome Sequencing", "WGSS", "Bos_taurus_UMD_3.1", "Illumina",
-                                               new URI("http://www.cs1.org"), new String[]{"1", "2"}, 1300, 12);
+                                               new URI("http://www.cs1.org"), new String[]{"1", "2"}, 1300, 12, false);
         given(studyEvaproDBAdaptor.getAllStudies(anyObject()))
                 .willReturn(encapsulateInQueryResult(study1, study2, study3));
         Map<String, Long> studiesGroupedBySpeciesName = Stream.of(study1, study2, study3).collect(
@@ -138,17 +140,17 @@ public class ArchiveWSServerTest {
                                                  "Human", "Homo Sapiens", "Germline", "EBI", "DNA", "multi-isolate",
                                                  StudyType.CASE_CONTROL, "Exome Sequencing", "ES",
                                                  "GRCh37", "Illumina", new URI("http://www.s1.org"), new String[]{"10"},
-                                                 1000, 10);
+                                                 1000, 10, false);
         VariantStudy svStudy2 = new VariantStudy("Human SVV Test study 2", "svS2", null, "SV study 2 description",
                                                  new int[]{9606}, "Human", "Homo Sapiens", "Germline", "EBI", "DNA",
                                                  "multi-isolate", StudyType.AGGREGATE, "Exome Sequencing",
                                                  "ES", "GRCh38", "Illumina", new URI("http://www.s2.org"),
-                                                 new String[]{"13"}, 5000, 4);
+                                                 new String[]{"13"}, 5000, 4, false);
         VariantStudy svStudy3 = new VariantStudy("Cow SV Test study 1", "svCS1", null, "SV cow study 1 description",
-                                               new int[]{9913}, "Cow", "Bos taurus", "Germline", "EBI", "DNA",
-                                               "multi-isolate", StudyType.AGGREGATE,
-                                               "Whole Genome Sequencing", "WGSS", "Bos_taurus_UMD_3.1", "Illumina",
-                                               new URI("http://www.cs1.org"), new String[]{"1", "2"}, 1300, 12);
+                                                 new int[]{9913}, "Cow", "Bos taurus", "Germline", "EBI", "DNA",
+                                                 "multi-isolate", StudyType.AGGREGATE,
+                                                 "Whole Genome Sequencing", "WGSS", "Bos_taurus_UMD_3.1", "Illumina",
+                                                 new URI("http://www.cs1.org"), new String[]{"1", "2"}, 1300, 12, false);
         given(studyDgvaDBAdaptor.getAllStudies(anyObject()))
                   .willReturn(encapsulateInQueryResult(svStudy1, svStudy2, svStudy3));
 


### PR DESCRIPTION
Add the attribute `browsable` to VariantStudy and EvaStudyBrowser, so that the endpoint meta/studies/all returns studies with a flag telling if it is browsable or not. All browsable studies have at least one file in the table `browsable_file`.

evapro needs to update the materialized view `study_browser` to add 
```
, COALESCE(browsable_table.browsable, false) AS browsable
```
 and 
```
LEFT JOIN ( SELECT browsable_file.project_accession,
            true AS browsable
           FROM browsable_file
          GROUP BY browsable_file.project_accession) browsable_table(project_accession_browsable, browsable) 
  ON browsable_table.project_accession_browsable::text = project.project_accession::text
```

the full command for creating the materialized view is now in eva-lib/src/main/resources/study_browser.sql.