### PR TITLE
DGVA-91 DGVA study browser filters

### DIFF
--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/dgva_utils/DgvaDBUtils.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/dgva_utils/DgvaDBUtils.java
@@ -22,6 +22,7 @@ import uk.ac.ebi.eva.lib.utils.QueryOptions;
 import uk.ac.ebi.eva.lib.utils.QueryOptionsConstants;
 
 import static org.springframework.data.jpa.domain.Specifications.where;
+import static uk.ac.ebi.eva.lib.extension.GenericSpecifications.ilike;
 import static uk.ac.ebi.eva.lib.extension.GenericSpecifications.in;
 import static uk.ac.ebi.eva.lib.extension.GenericSpecifications.like;
 
@@ -40,8 +41,8 @@ public class DgvaDBUtils {
 
             for (String speciesName : species) {
                 speciesSpecifications = speciesSpecifications
-                        .or(like(DgvaStudyBrowserRepository.COMMON_NAME, "%" + speciesName + "%"))
-                        .or(like(DgvaStudyBrowserRepository.SCIENTIFIC_NAME, "%" + speciesName + "%"));
+                        .or(ilike(DgvaStudyBrowserRepository.COMMON_NAME, "%" + speciesName + "%"))
+                        .or(ilike(DgvaStudyBrowserRepository.SCIENTIFIC_NAME, "%" + speciesName + "%"));
             }
         }
 
@@ -50,7 +51,7 @@ public class DgvaDBUtils {
             String[] types = queryOptions.getAsStringList(QueryOptionsConstants.TYPE).toArray(new String[]{});
             typeSpecifications = where(in(DgvaStudyBrowserRepository.STUDY_TYPE, (Object[])types));
             for (String type : types) {
-                typeSpecifications = typeSpecifications.or(like(DgvaStudyBrowserRepository.STUDY_TYPE, "%" + type + "%"));
+                typeSpecifications = typeSpecifications.or(ilike(DgvaStudyBrowserRepository.STUDY_TYPE, "%" + type + "%"));
             }
         }
 

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/dgva_utils/DgvaDBUtils.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/dgva_utils/DgvaDBUtils.java
@@ -24,7 +24,6 @@ import uk.ac.ebi.eva.lib.utils.QueryOptionsConstants;
 import static org.springframework.data.jpa.domain.Specifications.where;
 import static uk.ac.ebi.eva.lib.extension.GenericSpecifications.ilike;
 import static uk.ac.ebi.eva.lib.extension.GenericSpecifications.in;
-import static uk.ac.ebi.eva.lib.extension.GenericSpecifications.like;
 
 public class DgvaDBUtils {
 

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/dgva_utils/DgvaDBUtils.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/dgva_utils/DgvaDBUtils.java
@@ -34,8 +34,15 @@ public class DgvaDBUtils {
 
         Specifications speciesSpecifications = null;
         if (queryOptions.containsKey(QueryOptionsConstants.SPECIES)) {
-            Object[] species = queryOptions.getAsStringList(QueryOptionsConstants.SPECIES).toArray(new String[]{});
-            speciesSpecifications = where(in(DgvaStudyBrowserRepository.COMMON_NAME, species)).or(in(DgvaStudyBrowserRepository.SCIENTIFIC_NAME, species));
+            String[] species = queryOptions.getAsStringList(QueryOptionsConstants.SPECIES).toArray(new String[]{});
+            speciesSpecifications = where(in(DgvaStudyBrowserRepository.COMMON_NAME, (Object[])species))
+                    .or(in(DgvaStudyBrowserRepository.SCIENTIFIC_NAME, (Object[])species));
+
+            for (String speciesName : species) {
+                speciesSpecifications = speciesSpecifications
+                        .or(like(DgvaStudyBrowserRepository.COMMON_NAME, "%" + speciesName + "%"))
+                        .or(like(DgvaStudyBrowserRepository.SCIENTIFIC_NAME, "%" + speciesName + "%"));
+            }
         }
 
         Specifications typeSpecifications = null;

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/extension/GenericSpecifications.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/extension/GenericSpecifications.java
@@ -35,7 +35,18 @@ public class GenericSpecifications<T> {
         return new Specification<T>() {
             @Override
             public Predicate toPredicate(Root<T> root, CriteriaQuery<?> criteriaQuery, CriteriaBuilder criteriaBuilder) {
-                return criteriaBuilder.like(root.get(attributeName),pattern);
+                return criteriaBuilder.like(root.get(attributeName), pattern);
+            }
+        };
+    }
+
+
+    public static <T> Specification<T> ilike(String attributeName, String pattern) {
+        return new Specification<T>() {
+            @Override
+            public Predicate toPredicate(Root<T> root, CriteriaQuery<?> criteriaQuery, CriteriaBuilder criteriaBuilder) {
+                return criteriaBuilder.like(criteriaBuilder.lower(root.get(attributeName)),
+                                            criteriaBuilder.lower(criteriaBuilder.literal(pattern)));
             }
         };
     }


### PR DESCRIPTION
DGVa study browser filter by species fixed for comma-separated lists of them. For instance, queries to "chimpanzee" didn't return any results before because this species was always part of studies where multiple primate species were sequenced.
