### PR TITLE
EVA-1119 Fix GitLab CI build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ stages:
     stage: build
     variables:
         ARTIFACT_PATH: "eva-server/target/eva-$ENVIRONMENT_NAME.war"
+        _JAVA_OPTIONS: "-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
     script:
         - "mvn package --settings .gitlab.settings.xml -P $MAVEN_PROFILE"
         - "cp eva-server/target/eva.war $ARTIFACT_PATH"
@@ -20,6 +21,8 @@ stages:
 maven-test:
     image: maven:3.5.4-jdk-8
     stage: test
+    variables:
+        _JAVA_OPTIONS: "-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
     script:
         - mvn verify --settings .gitlab.settings.xml
     artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
         _JAVA_OPTIONS: "-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
     script:
         - "mvn package --settings .gitlab.settings.xml -P $MAVEN_PROFILE"
-        - "cp eva-server/target/eva.war $ARTIFACT_PATH"
+        - "cp eva-server/target/eva-*.war $ARTIFACT_PATH"
     artifacts:
         paths:
             - "$ARTIFACT_PATH"


### PR DESCRIPTION
[An issue on JDK8-u181](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925) makes the GitLab CI build fail because the `ForkedBooter` class can't be found. This bugfix is based on the suggestion made in [this StackOverflow message](https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class/53085816#53085816).

In addition to that, after adding the commit number to the built WAR file, it was no longer copying the artifact for deployment. By using a wildcard it recognizes the new naming style.