### PR TITLE
EVA-1119 Fix URL Gitlab CI build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,8 +46,8 @@ maven-test:
         - "apk add --update curl"
         - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
         # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)
-        - "echo curl -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_USER:$TOMCAT_PASSWORD@$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
-        - "curl -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_USER:$TOMCAT_PASSWORD@$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
+        - "echo curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
+        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" -w %{url_effective} \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
 
 maven-build-internal:
     extends: .maven-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,10 +45,9 @@ maven-test:
     script:
         - "apk add --update curl"
         - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
-        #- "export TOMCAT_PATH=eva%23%23$VERSION"
-        #- "echo http://$TOMCAT_HOST/manager/text/deploy?path=/eva##$VERSION^&update=true"
-        #- "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva##$VERSION\" | grep \"OK - Deployed application\""
-        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?path=/eva#/EVA1119\" | grep \"OK - Deployed application\""
+        - "echo curl -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?path=/eva&version=$VERSION&update=true\" "
+        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?path=/eva&version=$VERSION&update=true\" 
+        #| grep \"OK - Deployed application\""
 
 maven-build-internal:
     extends: .maven-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ maven-test:
         - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
         # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)
         - "echo curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
-        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" -w %{url_effective} \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
+        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" -w %{url_effective} \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva\""
 
 maven-build-internal:
     extends: .maven-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ maven-test:
     script:
         - "apk add --update curl"
         - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
+        # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)
         - "echo curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
         - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,12 +42,14 @@ maven-test:
         url: "http://$TOMCAT_HOST/eva/webservices/rest/swagger-ui.html"
     variables:
         ARTIFACT_PATH: "eva-server/target/eva-$ENVIRONMENT_NAME.war"
+    before_script:
+        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
+        - "echo $VERSION"
     script:
         - "apk add --update curl"
-        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
         # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)
         - "echo curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
-        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" -w %{url_effective} \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
+        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
 
 maven-build-internal:
     extends: .maven-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,12 +42,13 @@ maven-test:
         url: "http://$TOMCAT_HOST/eva/webservices/rest/swagger-ui.html"
     variables:
         ARTIFACT_PATH: "eva-server/target/eva-$ENVIRONMENT_NAME.war"
-        VERSION: $(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')
+    before_script:
+        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
     script:
         - "apk add --update curl"
         # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)
-        - "echo curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
-        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
+        - "echo curl -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_USER:$TOMCAT_PASSWORD@$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
+        - "curl -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_USER:$TOMCAT_PASSWORD@$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
 
 maven-build-internal:
     extends: .maven-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,8 @@ maven-test:
         ARTIFACT_PATH: "eva-server/target/eva-$ENVIRONMENT_NAME.war"
     script:
         - "apk add --update curl"
-        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?path=/eva/EVA1288&update=true\" | grep \"OK - Deployed application\""
+        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '[.*')"
+        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?path=/eva##$VERSION&update=true\" | grep \"OK - Deployed application\""
 
 maven-build-internal:
     extends: .maven-build
@@ -60,6 +61,7 @@ maven-build-development:
         MAVEN_PROFILE: "development,evadev,dgvadev"
         ENVIRONMENT_NAME: "development"
     only:
+        - hotfix/gitlabci-artifact
         - master
 
 maven-build-production:
@@ -88,6 +90,7 @@ deploy-tomcat-development:
         TOMCAT_HOST: "$TOMCAT_DEVELOPMENT_HOST"
         ENVIRONMENT_NAME: "development"
     only:
+        - hotfix/gitlabci-artifact
         - master
 
 deploy-tomcat-production:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,9 +45,8 @@ maven-test:
     script:
         - "apk add --update curl"
         - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
-        - "echo curl -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?path=/eva&version=$VERSION&update=true\" "
-        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?path=/eva&version=$VERSION&update=true\" 
-        #| grep \"OK - Deployed application\""
+        - "echo curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
+        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
 
 maven-build-internal:
     extends: .maven-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,10 +42,9 @@ maven-test:
         url: "http://$TOMCAT_HOST/eva/webservices/rest/swagger-ui.html"
     variables:
         ARTIFACT_PATH: "eva-server/target/eva-$ENVIRONMENT_NAME.war"
-    before_script:
-        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
     script:
         - "apk add --update curl"
+        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
         # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)
         - "echo curl -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_USER:$TOMCAT_PASSWORD@$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
         - "curl -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_USER:$TOMCAT_PASSWORD@$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,10 +44,7 @@ maven-test:
         ARTIFACT_PATH: "eva-server/target/eva-$ENVIRONMENT_NAME.war"
     script:
         - "apk add --update curl"
-        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
-        # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)
-        - "echo curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
-        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" -w %{url_effective} \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva\""
+        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva\" | grep \"OK - Deployed application\""
 
 maven-build-internal:
     extends: .maven-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ maven-test:
 
 # Not executed, parent job definition for Tomcat deployments
 .deploy-tomcat:
-    image: alpine:3.8
+    image: maven:3.5.4-jdk-8-alpine
     stage: deploy
     environment:
         name: $ENVIRONMENT_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ maven-test:
         - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
         # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)
         - "echo curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
-        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
+        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" -w %{url_effective} \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva&version=$VERSION\""
 
 maven-build-internal:
     extends: .maven-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,8 +44,11 @@ maven-test:
         ARTIFACT_PATH: "eva-server/target/eva-$ENVIRONMENT_NAME.war"
     script:
         - "apk add --update curl"
-        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '[.*')"
-        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?path=/eva##$VERSION&update=true\" | grep \"OK - Deployed application\""
+        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
+        #- "export TOMCAT_PATH=eva%23%23$VERSION"
+        #- "echo http://$TOMCAT_HOST/manager/text/deploy?path=/eva##$VERSION^&update=true"
+        #- "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva##$VERSION\" | grep \"OK - Deployed application\""
+        - "curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T \"$ARTIFACT_PATH\" \"http://$TOMCAT_HOST/manager/text/deploy?path=/eva#/EVA1119\" | grep \"OK - Deployed application\""
 
 maven-build-internal:
     extends: .maven-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ maven-test:
         url: "http://$TOMCAT_HOST/eva/webservices/rest/swagger-ui.html"
     variables:
         ARTIFACT_PATH: "eva-server/target/eva-$ENVIRONMENT_NAME.war"
-        VERSION: "$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
+        VERSION: $(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')
     script:
         - "apk add --update curl"
         # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,9 +42,7 @@ maven-test:
         url: "http://$TOMCAT_HOST/eva/webservices/rest/swagger-ui.html"
     variables:
         ARTIFACT_PATH: "eva-server/target/eva-$ENVIRONMENT_NAME.war"
-    before_script:
-        - "export VERSION=$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
-        - "echo $VERSION"
+        VERSION: "$(mvn --non-recursive help:evaluate -Dexpression=project.version | grep -v '\\[.*')"
     script:
         - "apk add --update curl"
         # TODO The first command replaces $VERSION correctly, but not the cURL command (which works with an explicitly defined version)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,6 @@ maven-build-development:
         MAVEN_PROFILE: "development,evadev,dgvadev"
         ENVIRONMENT_NAME: "development"
     only:
-        - hotfix/gitlabci-artifact
         - master
 
 maven-build-production:
@@ -89,7 +88,6 @@ deploy-tomcat-development:
         TOMCAT_HOST: "$TOMCAT_DEVELOPMENT_HOST"
         ENVIRONMENT_NAME: "development"
     only:
-        - hotfix/gitlabci-artifact
         - master
 
 deploy-tomcat-production:


### PR DESCRIPTION
Remove `EVA1288` from the URL
The deployment to tomcat still does not include the version 