### PR TITLE
Improve variant ws server v2

### DIFF
--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2.java
@@ -21,6 +21,8 @@ package uk.ac.ebi.eva.server.ws;
 
 import io.swagger.annotations.Api;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -51,22 +53,20 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 @RestController
 @RequestMapping(value = "/v2/variants", produces = "application/json")
 @Api(tags = {"variants"})
-public class VariantWSServerV2 extends EvaWSServer {
+public class VariantWSServerV2  {
 
     @Autowired
     private VariantWithSamplesAndAnnotationsService service;
 
     @GetMapping(value = "/{variantCoreString}")
-    public Resource getCoreInfo(@PathVariable("variantCoreString") String variantCoreString,
-                                @RequestParam(name = "species") String species,
-                                @RequestParam(name = "assembly") String assembly,
-                                HttpServletResponse response) throws IllegalArgumentException {
-        initializeQuery();
+    public ResponseEntity getCoreInfo(@PathVariable("variantCoreString") String variantCoreString,
+                                      @RequestParam(name = "species") String species,
+                                      @RequestParam(name = "assembly") String assembly,
+                                      HttpServletResponse response) throws IllegalArgumentException {
         try {
             checkParameters(variantCoreString, null, null, species, assembly);
         } catch (IllegalArgumentException e) {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return new Resource<>(setErrorQueryResponse(e.getMessage()));
+            return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
 
         MultiMongoDbFactory.setDatabaseNameForCurrentThread(DBAdaptorConnector.getDBName(species + "_" + assembly));
@@ -76,23 +76,18 @@ public class VariantWSServerV2 extends EvaWSServer {
         try {
             variantEntity = getVariantByCoordinatesAndAnnotationVersion(variantCoreString, null, null);
         } catch (AnnotationMetadataNotFoundException | IllegalArgumentException ex) {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return new Resource<>(setQueryResponse(ex.getMessage()));
+            return new ResponseEntity(ex.getMessage(), HttpStatus.BAD_REQUEST);
         }
 
-        List<Variant> variantList = new ArrayList<>();
         if (!variantEntity.isPresent()) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            return new Resource<>(setQueryResponse(variantList));
+            return new ResponseEntity(null,HttpStatus.NOT_FOUND);
         }
 
         VariantWithSamplesAndAnnotation retrievedVariant = variantEntity.get();
         Variant variant = new Variant(retrievedVariant.getChromosome(), retrievedVariant.getStart(),
                 retrievedVariant.getEnd(), retrievedVariant.getReference(), retrievedVariant.getAlternate());
         variant.setIds(variantEntity.get().getIds());
-        variantList.add(variant);
-
-        QueryResult<Variant> queryResult = buildQueryResult(variantList, 1);
 
         Link annotationLink = new Link(linkTo(methodOn(VariantWSServerV2.class).getAnnotations(variantCoreString,
                 species, assembly, null, null, response)).toUri().toString(), "annotation");
@@ -103,7 +98,7 @@ public class VariantWSServerV2 extends EvaWSServer {
         List<Link> links = new ArrayList<>();
         links.add(sourcesLink);
         links.add(annotationLink);
-        return new Resource<>(setQueryResponse(queryResult), links);
+        return new ResponseEntity(new Resource<>(variant, links),HttpStatus.OK);
     }
 
     private void checkParameters(String variantCoreString, String annotationVepVersion,
@@ -161,7 +156,7 @@ public class VariantWSServerV2 extends EvaWSServer {
     }
 
     @GetMapping(value = "/{variantCoreString}/annotations")
-    public QueryResponse getAnnotations(@PathVariable("variantCoreString") String variantCoreString,
+    public ResponseEntity getAnnotations(@PathVariable("variantCoreString") String variantCoreString,
                                         @RequestParam(name = "species") String species,
                                         @RequestParam(name = "assembly") String assembly,
                                         @RequestParam(name = "annot-vep-version", required = false)
@@ -169,14 +164,11 @@ public class VariantWSServerV2 extends EvaWSServer {
                                         @RequestParam(name = "annot-vep-cache-version", required = false)
                                                 String annotationVepCacheVersion,
                                         HttpServletResponse response) throws IllegalArgumentException {
-        initializeQuery();
-
         try {
             checkParameters(variantCoreString, annotationVepVersion, annotationVepCacheVersion,
                     species, assembly);
         } catch (IllegalArgumentException e) {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return setErrorQueryResponse(e.getMessage());
+            return new ResponseEntity<>(e.getMessage(),HttpStatus.BAD_REQUEST);
         }
         MultiMongoDbFactory.setDatabaseNameForCurrentThread(DBAdaptorConnector.getDBName(species + "_" + assembly));
 
@@ -185,25 +177,17 @@ public class VariantWSServerV2 extends EvaWSServer {
             variantEntity = getVariantByCoordinatesAndAnnotationVersion(variantCoreString, annotationVepVersion,
                     annotationVepCacheVersion);
         } catch (AnnotationMetadataNotFoundException | IllegalArgumentException ex) {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return setQueryResponse(ex.getMessage());
+            return new ResponseEntity(ex.getMessage(),HttpStatus.BAD_REQUEST);
         }
 
-        List<Annotation> annotations = new ArrayList<>();
         if (!variantEntity.isPresent() || variantEntity.get().getAnnotation() == null) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            return setQueryResponse(buildQueryResult(annotations, 0));
+            return new ResponseEntity(null, HttpStatus.NOT_FOUND);
         }
-
-        annotations.add(variantEntity.get().getAnnotation());
-
-        QueryResult<Annotation> queryResult = buildQueryResult(annotations, annotations.size());
-
-        return setQueryResponse(queryResult);
+        return new ResponseEntity(variantEntity.get().getAnnotation(), HttpStatus.OK);
     }
 
     @GetMapping(value = "/{variantCoreString}/sources")
-    public QueryResponse getSources(@PathVariable("variantCoreString") String variantCoreString,
+    public ResponseEntity getSources(@PathVariable("variantCoreString") String variantCoreString,
                                     @RequestParam(name = "species") String species,
                                     @RequestParam(name = "assembly") String assembly,
                                     @RequestParam(name = "annot-vep-version", required = false)
@@ -211,14 +195,11 @@ public class VariantWSServerV2 extends EvaWSServer {
                                     @RequestParam(name = "annot-vep-cache-version", required = false)
                                             String annotationVepCacheVersion,
                                     HttpServletResponse response) throws IllegalArgumentException {
-        initializeQuery();
-
         try {
             checkParameters(variantCoreString, annotationVepVersion, annotationVepCacheVersion,
                     species, assembly);
         } catch (IllegalArgumentException e) {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return setErrorQueryResponse(e.getMessage());
+            return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
         MultiMongoDbFactory.setDatabaseNameForCurrentThread(DBAdaptorConnector.getDBName(species + "_" + assembly));
 
@@ -227,21 +208,19 @@ public class VariantWSServerV2 extends EvaWSServer {
             variantEntity = getVariantByCoordinatesAndAnnotationVersion(variantCoreString, annotationVepVersion,
                     annotationVepCacheVersion);
         } catch (AnnotationMetadataNotFoundException | IllegalArgumentException ex) {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return setQueryResponse(ex.getMessage());
+            return new ResponseEntity(ex.getMessage(), HttpStatus.BAD_REQUEST);
         }
 
         List<VariantSourceEntryWithSampleNames> variantSources = new ArrayList<>();
         if (!variantEntity.isPresent()) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            return setQueryResponse(buildQueryResult(variantSources, 0));
+            return new ResponseEntity(null, HttpStatus.NOT_FOUND);
         }
         variantEntity.get().getSourceEntries().forEach(sourceEntry -> {
             variantSources.add(sourceEntry);
         });
-        QueryResult<VariantSourceEntryWithSampleNames> queryResult = buildQueryResult(variantSources,
-                variantSources.size());
-
-        return setQueryResponse(queryResult);
+        if(variantSources.size()==0) {
+            return new ResponseEntity(null, HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity(variantSources, HttpStatus.OK);
     }
 }

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2.java
@@ -51,7 +51,7 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 @RestController
-@RequestMapping(value = "/v2/variants", produces = "application/json")
+@RequestMapping(value = "/v2/variants", produces = "application/hal+json")
 @Api(tags = {"variants"})
 public class VariantWSServerV2  {
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2.java
@@ -223,7 +223,7 @@ public class VariantWSServerV2 {
             resourceList.add(new Resource<>(sourceEntry));
         });
         Link coreVariantLink = new Link(linkTo(methodOn(VariantWSServerV2.class).getCoreInfo(variantCoreString,
-                species, assembly, response)).toUri().toString(), "CoreVariant");
+                species, assembly, response)).toUri().toString(), "coreVariant");
         if (resourceList.size() == 0) {
             return new ResponseEntity(new Resources<>(resourceList, coreVariantLink), HttpStatus.NOT_FOUND);
         }

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2.java
@@ -185,7 +185,7 @@ public class VariantWSServerV2 {
             return new ResponseEntity(null, HttpStatus.NOT_FOUND);
         }
         Link coreVariantLink = new Link(linkTo(methodOn(VariantWSServerV2.class).getCoreInfo(variantCoreString,
-                species, assembly, response)).toUri().toString(), "CoreVariant");
+                species, assembly, response)).toUri().toString(), "coreVariant");
 
         return new ResponseEntity(new Resource<>(variantEntity.get().getAnnotation(), coreVariantLink), HttpStatus.OK);
     }

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2IntegrationTest.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/VariantWSServerV2IntegrationTest.java
@@ -66,14 +66,19 @@ import static org.junit.Assert.*;
 public class VariantWSServerV2IntegrationTest {
 
     private static final String TEST_DB = "test-db";
+
     @Rule
     public MongoDbRule mongoDbRule = newMongoDbRule().defaultSpringMongoDb(TEST_DB);
+
     @Autowired
     MongoDbFactory mongoDbFactory;
+
     @Autowired
     private ApplicationContext applicationContext;
+
     @Autowired
     private TestRestTemplate restTemplate;
+
     @Autowired
     private VariantWithSamplesAndAnnotationsService service;
 
@@ -84,24 +89,25 @@ public class VariantWSServerV2IntegrationTest {
     @Test
     public void rootTestGetVariantsByVariantCoreString() throws URISyntaxException {
         String url = "/v2/variants/20:60100:A:T?species=mmusculus&assembly=grcm38";
-        List<VariantWithSamplesAndAnnotation> variantWithSamplesAndAnnotations = WSTestHelpers.testRestTemplateHelper(
-                url, restTemplate);
-        assertEquals(1, variantWithSamplesAndAnnotations.size());
-        assertTrue(variantWithSamplesAndAnnotations.get(0).getSourceEntries().isEmpty());
-        assertNull(variantWithSamplesAndAnnotations.get(0).getAnnotation());
-        assertTrue(variantWithSamplesAndAnnotations.get(0).getIds().size() > 0);
+        VariantWithSamplesAndAnnotation variantWithSamplesAndAnnotations = restTemplate.exchange(
+                url, HttpMethod.GET, null,
+                new ParameterizedTypeReference<VariantWithSamplesAndAnnotation>() {
+                }).getBody();
+        assertTrue(variantWithSamplesAndAnnotations.getSourceEntries().isEmpty());
+        assertNull(variantWithSamplesAndAnnotations.getAnnotation());
+        assertTrue(variantWithSamplesAndAnnotations.getIds().size() > 0);
     }
 
     @Test
     public void rootTestGetVariantsByNonExistingVariantCoreString() throws URISyntaxException {
         String url = "/v2/variants/10:0:A:T?species=mmusculus&assembly=grcm38";
+        testForNonExistingHelper(url);
+    }
 
-        ResponseEntity<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>> response = restTemplate.exchange(
-                url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<QueryResult<VariantWithSamplesAndAnnotation>>>() {
-                });
+    private void testForNonExistingHelper(String url) throws URISyntaxException {
+        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertEquals(0, response.getBody().getResponse().size());
+        assertNull(response.getBody());
     }
 
     @Test
@@ -117,33 +123,23 @@ public class VariantWSServerV2IntegrationTest {
     @Test
     public void annotationEndPointTestExisting() throws URISyntaxException {
         String url = "/v2/variants/20:60100:A:T/annotations?species=mmusculus&assembly=grcm38";
-        ResponseEntity<QueryResponse<QueryResult<Annotation>>> annotations = restTemplate.exchange(
-                url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<QueryResult<Annotation>>>() {
+        ResponseEntity<Annotation> annotations = restTemplate.exchange(url, HttpMethod.GET, null,
+                new ParameterizedTypeReference<Annotation>() {
                 });
         assertEquals(HttpStatus.OK, annotations.getStatusCode());
-        assertFalse(annotations.getBody().getResponse().get(0).getResult().get(0).getChromosome().isEmpty());
+        assertFalse(annotations.getBody().getChromosome().isEmpty());
     }
 
     @Test
     public void annotationEndPointTestForNonExistingAnnotationWithNonExistingVariant() throws URISyntaxException {
         String url = "/v2/variants/100:0:C:T/annotations?species=mmusculus&assembly=grcm38";
-        ResponseEntity<QueryResponse<QueryResult<Annotation>>> annotations = restTemplate.exchange(
-                url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<QueryResult<Annotation>>>() {
-                });
-        assertEquals(HttpStatus.NOT_FOUND, annotations.getStatusCode());
-        assertTrue(annotations.getBody().getResponse().get(0).getResult().size() == 0);
+        testForNonExistingHelper(url);
     }
 
     @Test
     public void annotationEndPointTestForNonExistingAnnotationWithExistingVariant() throws URISyntaxException {
         String url = "/v2/variants/X:1000014:G:A/annotations?species=mmusculus&assembly=grcm38";
-        ResponseEntity<QueryResponse<QueryResult<Annotation>>> annotations = restTemplate.exchange(url, HttpMethod.GET,
-                null, new ParameterizedTypeReference<QueryResponse<QueryResult<Annotation>>>() {
-                });
-        assertEquals(HttpStatus.NOT_FOUND, annotations.getStatusCode());
-        assertTrue(annotations.getBody().getResponse().get(0).getResult().size() == 0);
+        testForNonExistingHelper(url);
     }
 
     @Test
@@ -161,36 +157,30 @@ public class VariantWSServerV2IntegrationTest {
     @Test
     public void sourceEntriesEndPointTestExisting() throws URISyntaxException {
         String url = "/v2/variants/20:60100:A:T/sources?species=mmusculus&assembly=grcm38";
-        ResponseEntity<QueryResponse<QueryResult<VariantSourceEntryWithSampleNames>>> sources = restTemplate.
+        ResponseEntity<List<VariantSourceEntryWithSampleNames>> sources = restTemplate.
                 exchange(url, HttpMethod.GET, null,
-                        new ParameterizedTypeReference<QueryResponse<QueryResult
-                                <VariantSourceEntryWithSampleNames>>>() {
+                        new ParameterizedTypeReference<List<VariantSourceEntryWithSampleNames>>() {
                         });
         assertEquals(HttpStatus.OK, sources.getStatusCode());
-        assertFalse(sources.getBody().getResponse().get(0).getResult().get(0).getFileId().isEmpty());
+        assertFalse(sources.getBody().get(0).getFileId().isEmpty());
     }
 
     @Test
     public void sourceEntriesEndPointTestNonExistingWithNonExistingVariant() throws URISyntaxException {
         String url = "/v2/variants/100:0:C:T/sources?species=mmusculus&assembly=grcm38";
-        ResponseEntity<QueryResponse<QueryResult<VariantSourceEntryWithSampleNames>>> sources = restTemplate.
-                exchange(url, HttpMethod.GET, null, new ParameterizedTypeReference<QueryResponse<
-                        QueryResult<VariantSourceEntryWithSampleNames>>>() {
-                });
-        assertEquals(HttpStatus.NOT_FOUND, sources.getStatusCode());
-        assertTrue(sources.getBody().getResponse().get(0).getResult().isEmpty());
+        testForNonExistingHelper(url);
     }
 
     @Test
     public void sourceEntriesEndPointTestNonExistingWithExistingVariantAndNonExistingStatistics() throws
             URISyntaxException {
         String url = "/v2/variants/X:1000014:G:A/sources?species=mmusculus&assembly=grcm38";
-        ResponseEntity<QueryResponse<QueryResult<VariantSourceEntryWithSampleNames>>> sources = restTemplate.exchange
-                (url, HttpMethod.GET, null, new ParameterizedTypeReference<QueryResponse<QueryResult
-                        <VariantSourceEntryWithSampleNames>>>() {
-                });
+        ResponseEntity<List<VariantSourceEntryWithSampleNames>> sources = restTemplate.
+                exchange(url, HttpMethod.GET, null,
+                        new ParameterizedTypeReference<List<VariantSourceEntryWithSampleNames>>() {
+                        });
         assertEquals(HttpStatus.OK, sources.getStatusCode());
-        assertTrue(sources.getBody().getResponse().get(0).getResult().get(0).getCohortStats().isEmpty());
+        assertTrue(sources.getBody().get(0).getCohortStats().isEmpty());
     }
 
     @Test

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/WSTestHelpers.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/WSTestHelpers.java
@@ -63,12 +63,9 @@ public class WSTestHelpers {
 
     public static String testRestTemplateHelperForError(String url,
                                                         TestRestTemplate restTemplate) {
-        ResponseEntity<QueryResponse<String> > response = restTemplate.exchange(
-                url, HttpMethod.GET, null,
-                new ParameterizedTypeReference<QueryResponse<String>>() {
-                });
+        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
         assertEquals(HttpStatus.BAD_REQUEST,response.getStatusCode());
-        return response.getBody().getError();
+        return response.getBody();
     }
 
     public static void checkVariantsInFullResults(List<VariantWithSamplesAndAnnotation> results,


### PR DESCRIPTION
The purpose of this PR is to remove the usage of  `QueryResponse` in VariantWSServerV2 and associated tests.