### PR TITLE
bug fix and optimization for beaconquery

### DIFF
--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
@@ -100,7 +100,7 @@ public class BeaconServiceV2 {
 
         try {
             checkParameters(chromosome, referenceBases, start, end, alternateBases, variantType, assemblyId,
-                    includeDatasetResponses);
+                    includeDatasetResponses, startMin, startMax, endMin, endMax);
         } catch (IllegalArgumentException e) {
             return buildBeaconAlleleResponse(null, null, null, e.getMessage());
         }
@@ -139,7 +139,8 @@ public class BeaconServiceV2 {
 
     private void checkParameters(String chromosome, String referenceBases, Long start, Long end,
                                  String alternateBases, String variantType, String assemblyId,
-                                 String includeDatasetResponses) throws IllegalArgumentException {
+                                 String includeDatasetResponses, Long startMin, Long startMax, Long endMin,
+                                 Long endMax) throws IllegalArgumentException {
         if (chromosome == null || chromosome.length() == 0) {
             String errorMessage = "Please provide a valid reference name from ";
             throw new IllegalArgumentException(errorMessage + String.join(", ",
@@ -161,11 +162,18 @@ public class BeaconServiceV2 {
             throw new IllegalArgumentException("Please provide reference bases");
         }
 
-        if (start != null && start < 0) {
+        if (start == null) {
+            if (startMin == null || startMax == null) {
+                throw new IllegalArgumentException("Please provied either start or both startMin and startMax");
+            }
+        } else if (start < 0) {
             throw new IllegalArgumentException("Please provide a positive start number");
         }
-
-        if (end != null && end < 0) {
+        if (end == null) {
+            if (endMin == null || endMax == null) {
+                throw new IllegalArgumentException("Please provied either end or both endMin and endMax");
+            }
+        } else if (end < 0) {
             throw new IllegalArgumentException("Please provide a positive end number");
         }
 
@@ -265,7 +273,7 @@ public class BeaconServiceV2 {
                 if (variantMongo.getAlternate().equalsIgnoreCase(variantStatisticsMongo.getMafAllele()) ||
                         variantMongo.getReference().equalsIgnoreCase(variantStatisticsMongo.getMafAllele())) {
                     datasetIdToFrequencyMapper.put(variantStatisticsMongo.getStudyId() + "_" + variantStatisticsMongo
-                                    .getFileId(), variantStatisticsMongo.getMaf());
+                            .getFileId(), variantStatisticsMongo.getMaf());
                 }
             });
         });

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
@@ -167,8 +167,9 @@ public class BeaconServiceV2 {
         }
 
         if (start == null) {
-            if (startMin == null || startMax == null) {
-                throw new IllegalArgumentException("Please provide either start or both startMin and startMax");
+            if (startMin == null || startMax == null || endMin == null || endMax == null) {
+                throw new IllegalArgumentException("Please provide either start or both startMin,startMax and endMin" +
+                        ",endMax");
             }
         } else if (start < 0) {
             throw new IllegalArgumentException("Please provide a positive start number");

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
@@ -169,11 +169,7 @@ public class BeaconServiceV2 {
         } else if (start < 0) {
             throw new IllegalArgumentException("Please provide a positive start number");
         }
-        if (end == null) {
-            if (endMin == null || endMax == null) {
-                throw new IllegalArgumentException("Please provied either end or both endMin and endMax");
-            }
-        } else if (end < 0) {
+        if (end != null && end < 0) {
             throw new IllegalArgumentException("Please provide a positive end number");
         }
 

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
@@ -168,7 +168,7 @@ public class BeaconServiceV2 {
 
         if (start == null) {
             if (startMin == null || startMax == null) {
-                throw new IllegalArgumentException("Please provied either start or both startMin and startMax");
+                throw new IllegalArgumentException("Please provide either start or both startMin and startMax");
             }
         } else if (start < 0) {
             throw new IllegalArgumentException("Please provide a positive start number");

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/BeaconServiceV2.java
@@ -121,6 +121,10 @@ public class BeaconServiceV2 {
         List<VariantMongo> variantMongoList;
 
         if (pageSize > 0) {
+            if (includeDatasetResponses == null || IncludeDatasetResponsesEnum.valueOf(includeDatasetResponses) ==
+                    IncludeDatasetResponsesEnum.NONE) {
+                return buildBeaconAlleleResponse(true, request, null, null);
+            }
             variantMongoList = service.findByRegionAndOtherBeaconFilters(startRange, endRange, filters,
                     new PageRequest(0, pageSize));
         } else {

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/GA4GHBeaconWSServerV2Test.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/GA4GHBeaconWSServerV2Test.java
@@ -175,8 +175,8 @@ public class GA4GHBeaconWSServerV2Test {
                 .queryParam("assemblyId", "GRch37")
                 .build().toString();
         assertEquals(400, testBeaconHelper(url).getBody().get(0).getError().getErrorCode().intValue());
-        assertEquals("Please provied either start or both startMin and startMax", testBeaconHelper(url).
-                getBody().get(0).getError().getErrorMessage());
+        assertEquals("Please provide either start or both startMin,startMax and endMin,endMax",
+                testBeaconHelper(url).getBody().get(0).getError().getErrorMessage());
     }
 
     private ResponseEntity<List<BeaconAlleleResponse>> testBeaconHelper(String url) {

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/GA4GHBeaconWSServerV2Test.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/ws/ga4gh/beaconv2/GA4GHBeaconWSServerV2Test.java
@@ -70,7 +70,7 @@ public class GA4GHBeaconWSServerV2Test {
         Region startRange = new Region("X", 100470026L, 100470026L);
         Region endRange = new Region("X", 100470026L, 100470026L);
         List<VariantRepositoryFilter> variantRepositoryFilters = new FilterBuilder().getBeaconFilters("G", "A",
-               null, Arrays.asList("PRJEB7218"));
+                null, Arrays.asList("PRJEB7218"));
 
         Pageable pageable = new PageRequest(0, 1);
         given(service.findByRegionAndOtherBeaconFilters(eq(startRange), eq(endRange), eq(variantRepositoryFilters),
@@ -139,6 +139,8 @@ public class GA4GHBeaconWSServerV2Test {
         request.setAssemblyId("GRCh37");
         request.setReferenceBases("G");
         request.setAlternateBases("A");
+        request.setStart(0L);
+        request.setEnd(0);
 
         String url = UriComponentsBuilder.fromUriString("")
                 .path("/v2/beacon/query")
@@ -146,6 +148,8 @@ public class GA4GHBeaconWSServerV2Test {
                 .queryParam("referenceBases", request.getReferenceBases())
                 .queryParam("assemblyId", request.getAssemblyId())
                 .queryParam("alternateBases", request.getAlternateBases())
+                .queryParam("start", request.getStart())
+                .queryParam("end", request.getEnd())
                 .build().toString();
         assertFalse(testBeaconHelper(url).getBody().get(0).isExists());
     }
@@ -157,9 +161,21 @@ public class GA4GHBeaconWSServerV2Test {
                 .queryParam("referenceName", "X")
                 .queryParam("referenceBases", "G")
                 .queryParam("assemblyId", "GRch37")
+                .queryParam("start", 0)
+                .queryParam("end", 0)
                 .build().toString();
         assertEquals(400, testBeaconHelper(url).getBody().get(0).getError().getErrorCode().intValue());
         assertEquals("Either the alternate bases or the variant type is required", testBeaconHelper(url).
+                getBody().get(0).getError().getErrorMessage());
+
+        url = UriComponentsBuilder.fromUriString("")
+                .path("/v2/beacon/query")
+                .queryParam("referenceName", "X")
+                .queryParam("referenceBases", "G")
+                .queryParam("assemblyId", "GRch37")
+                .build().toString();
+        assertEquals(400, testBeaconHelper(url).getBody().get(0).getError().getErrorCode().intValue());
+        assertEquals("Please provied either start or both startMin and startMax", testBeaconHelper(url).
                 getBody().get(0).getError().getErrorMessage());
     }
 
@@ -180,7 +196,7 @@ public class GA4GHBeaconWSServerV2Test {
                 .queryParam("alternateBases", "A")
                 .queryParam("start", 100470026L)
                 .queryParam("end", 100470026L)
-                .queryParam("datasetIds" ,String.join(",", Arrays.asList("PRJEB7218")))
+                .queryParam("datasetIds", String.join(",", Arrays.asList("PRJEB7218")))
                 .queryParam("variantType", "SNV")
                 .build().toString();
         assertFalse(testBeaconHelper(url).getBody().get(0).isExists());


### PR DESCRIPTION
The purpose of this PR is to add checks so that querying of imprecise queries is only allowed when all of startMin,startMax,endMin and endMax are present.

Also, in the case where `includeDatasetResponses` is `None`, an optimization is done by not calling `findByRegionAndOtherBeaconFilters` 