### PR TITLE
EVA-1104 - Take out mappings for 2KB upstream and downstream variants per VEP

### DIFF
--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/ConsequenceTypeMappings.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/ConsequenceTypeMappings.java
@@ -67,9 +67,7 @@ public class ConsequenceTypeMappings {
         termToAccession.put("intergenic_variant", 1628);
         termToAccession.put("lincRNA", 1463);
         termToAccession.put("downstream_gene_variant", 1632);
-        termToAccession.put("2KB_downstream_gene_variant", 1632);
         termToAccession.put("upstream_gene_variant", 1631);
-        termToAccession.put("2KB_upstream_gene_variant", 1631);
         termToAccession.put("SNV", 1483);
         termToAccession.put("SNP", 694);
         termToAccession.put("RNA_polymerase_promoter", 1203);
@@ -81,7 +79,7 @@ public class ConsequenceTypeMappings {
 
         // Fill the accession to term map
         for(String key : termToAccession.keySet()) {
-            accessionToTerm.put(termToAccession.get(key), key);
+            accessionToTerm.putIfAbsent(termToAccession.get(key), key);
         }
     }
 

--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/ConsequenceTypeMappings.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/utils/ConsequenceTypeMappings.java
@@ -15,7 +15,7 @@
  */
 package uk.ac.ebi.eva.lib.utils;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -24,9 +24,9 @@ import java.util.Map;
  */
 public class ConsequenceTypeMappings {
 
-    public static final Map<String, Integer> termToAccession = new HashMap<>();
+    public static final Map<String, Integer> termToAccession = new LinkedHashMap<>();
 
-    public static final Map<Integer, String> accessionToTerm = new HashMap<>();
+    public static final Map<Integer, String> accessionToTerm = new LinkedHashMap<>();
 
     static {
         // Fill the term to accession map


### PR DESCRIPTION
After fix, most severe consequence type appears correctly: https://wwwdev.ebi.ac.uk/eva/?Variant-Browser&species=ecaballus_20&selectFilter=region&region=1%3A260000-270000