### PR TITLE
EVA-1902 - Fix Spring Boot 2 application deployment issues

### DIFF
--- a/eva-lib/src/main/java/uk/ac/ebi/eva/lib/MongoConfiguration.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/eva/lib/MongoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -158,5 +159,11 @@ public class MongoConfiguration {
         }
 
         return new MongoClient(servers, mongoCredentialList, options);
+    }
+
+    @Bean
+    public MongoDbFactory mongoDbFactory(SpringDataMongoDbProperties springDataMongoDbProperties) throws Exception {
+        return new SimpleMongoDbFactory(getMongoClient(springDataMongoDbProperties),
+                                        springDataMongoDbProperties.getDatabase());
     }
 }

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/configuration/MongoEvaLibConfiguration.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/configuration/MongoEvaLibConfiguration.java
@@ -1,8 +1,12 @@
 package uk.ac.ebi.eva.server.configuration;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 
 import uk.ac.ebi.eva.lib.MongoConfiguration;
 import uk.ac.ebi.eva.lib.MultiMongoFactoryConfiguration;
@@ -10,4 +14,12 @@ import uk.ac.ebi.eva.lib.MultiMongoFactoryConfiguration;
 @Configuration
 @Import({MongoConfiguration.class, MultiMongoFactoryConfiguration.class})
 public class MongoEvaLibConfiguration {
+
+    @Bean
+    public MongoTemplate mongoTemplate(@Autowired MongoDbFactory mongoDbFactory,
+                                       @Autowired MappingMongoConverter mappingMongoConverter)
+    {
+        MongoTemplate template = new MongoTemplate(mongoDbFactory, mappingMongoConverter);
+        return template;
+    }
 }

--- a/eva-server/src/main/resources/application.properties
+++ b/eva-server/src/main/resources/application.properties
@@ -36,5 +36,7 @@ management.info.git.mode=full
 
 spring.jmx.default-domain=eva.ebi.ac.uk.|timestamp|
 
+# Spring Boot 2 MongoDB driver needs an authentication mechanism
+spring.data.mongodb.authentication-mechanism=SCRAM-SHA-1
 # See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
 spring.main.allow-bean-definition-overriding=true

--- a/eva-server/src/test/java/uk/ac/ebi/eva/server/configuration/MongoRepositoryTestConfiguration.java
+++ b/eva-server/src/test/java/uk/ac/ebi/eva/server/configuration/MongoRepositoryTestConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import uk.ac.ebi.eva.lib.MongoConfiguration;
 import uk.ac.ebi.eva.lib.Profiles;
 import uk.ac.ebi.eva.lib.configuration.SpringDataMongoDbProperties;
+import uk.ac.ebi.eva.lib.eva_utils.DBAdaptorConnector;
 
 @Configuration
 @Import({MongoConfiguration.class})
@@ -48,7 +49,7 @@ public class MongoRepositoryTestConfiguration {
 
     @Bean
     public MongoClient mongoClient(SpringDataMongoDbProperties properties) throws Exception {
-        return MongoConfiguration.getMongoClient(properties);
+        return DBAdaptorConnector.getMongoClient(properties);
     }
 
     @Bean


### PR DESCRIPTION
When attempting to deploy eva-ws after the [Spring 2 upgrade PR](https://github.com/EBIvariation/eva-ws/pull/137), there were some issues encountered:

- Spring Boot 2 requires an explicit MongoTemplate bean (fixed in this PR)
- Spring Boot 2 also requires an explicit authentication mechanism to be specified if there is a username and password supplied (fixed in this PR)
- HTTP 500 error thrown when attempting to test the variant endpoint. This is due to the binary type in the **files.attrs.src** MongoDB attribute (Variant source) not being directly castable to "byte[]" with the Spring Boot 2 MongoDB Java Driver. This is addressed in [another PR](https://github.com/EBIvariation/variation-commons/pull/94)