### PR TITLE
EVA-2823 - Use production_processing profile instead of evapro-staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ package-production:
     extends: .package
     variables:
         WS_MAVEN_PROFILE: production,$ACTIVE_EVAPRO
-        COUNT_STATS_MAVEN_PROFILE: production,evapro-staging
+        COUNT_STATS_MAVEN_PROFILE: production_processing
         ENVIRONMENT_NAME: production
     only:
         - tags


### PR DESCRIPTION
Based on Nitin's comment [here](https://docs.google.com/document/d/1kisKFmtCg9rCGFOlb7gqf4j1GgHIGBcmhSVaRJGQPvw/edit?disco=AAAAaAzdBTA), use production_processing profile.