### PR TITLE
Security fixes

### DIFF
--- a/count-stats/src/main/java/uk/ac/ebi/eva/countstats/authentication/SecurityConfiguration.java
+++ b/count-stats/src/main/java/uk/ac/ebi/eva/countstats/authentication/SecurityConfiguration.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.eva.countstats.authentication;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -9,6 +10,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -31,9 +34,17 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         this.customBasicAuthenticationEntryPoint = customBasicAuthenticationEntryPoint;
     }
 
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
     @Autowired
     public void configureGlobalSecurity(AuthenticationManagerBuilder auth) throws Exception {
-        auth.inMemoryAuthentication().withUser(USERNAME_ADMIN).password("{noop}" + PASSWORD_ADMIN).roles(ROLE_ADMIN);
+        auth.inMemoryAuthentication()
+                .withUser(USERNAME_ADMIN)
+                .password(passwordEncoder().encode(PASSWORD_ADMIN))
+                .roles(ROLE_ADMIN);
     }
 
     @Override

--- a/dbsnp-import/src/main/resources/application.properties
+++ b/dbsnp-import/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.jpa.generate-ddl=false
 spring.data.rest.base-path=/v1/
 
 management.endpoints.web.exposure.include=info,health
-management.info.git.mode=full
+management.info.git.mode=simple
 
 # See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
 spring.main.allow-bean-definition-overriding=true

--- a/dgva-server/src/main/resources/application.properties
+++ b/dgva-server/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jmx.enabled = false
 springfox.documentation.swagger.v2.path=/webservices/api
 
 management.endpoints.web.exposure.include=info,health
-management.info.git.mode=full
+management.info.git.mode=simple
 
 # See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
 spring.main.allow-bean-definition-overriding=true

--- a/eva-release/src/main/resources/application.properties
+++ b/eva-release/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.jpa.hibernate.ddl-auto=none
 spring.data.rest.base-path=/v1/
 
 management.endpoints.web.exposure.include=info,health
-management.info.git.mode=full
+management.info.git.mode=simple
 
 # See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
 spring.main.allow-bean-definition-overriding=true

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/RateLimiterAspect.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/RateLimiterAspect.java
@@ -66,13 +66,9 @@ public class RateLimiterAspect {
             throw new IllegalArgumentException(RATE_LIMIT_PRECONDITION_FAIL);
         }
         Object lastParam = args[args.length - 1];
-        // Get client IP address
-        // To account for clients which are behind a proxy server or a load balancer,
-        // use the client IP address via the HTTP request header X-Forwarded-For (XFF).
         if (lastParam instanceof HttpServletRequest) {
             HttpServletRequest request = (HttpServletRequest) lastParam;
-            String ipAddress = request.getHeader("X-FORWARDED-FOR");
-            return ipAddress == null ? request.getRemoteAddr() : ipAddress;
+            return request.getRemoteAddr();
         } else {
             throw new IllegalArgumentException(RATE_LIMIT_PRECONDITION_FAIL);
         }

--- a/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/contigalias/ContigAliasService.java
+++ b/eva-server/src/main/java/uk/ac/ebi/eva/server/ws/contigalias/ContigAliasService.java
@@ -27,6 +27,8 @@ import uk.ac.ebi.eva.commons.core.models.contigalias.ContigAliasTranslator;
 import uk.ac.ebi.eva.commons.core.models.contigalias.ContigNamingConvention;
 import uk.ac.ebi.eva.commons.core.models.ws.VariantWithSamplesAndAnnotation;
 
+import org.springframework.web.util.UriComponentsBuilder;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -159,7 +161,10 @@ public class ContigAliasService {
         if (contigNamingConvention == null) {
             return "";
         }
-        String url = contigAliasUrl + CONTIG_ALIAS_CHROMOSOMES_GENBANK_ENDPOINT + insdcContig;
+        String url = UriComponentsBuilder.fromHttpUrl(contigAliasUrl)
+                .path(CONTIG_ALIAS_CHROMOSOMES_GENBANK_ENDPOINT + "{contig}")
+                .buildAndExpand(insdcContig)
+                .toUriString();
         ContigAliasResponse contigAliasResponse = restTemplate.getForObject(url, ContigAliasResponse.class);
         if (contigAliasResponse == null || contigAliasResponse.getEmbedded() == null) {
             return "";
@@ -186,7 +191,10 @@ public class ContigAliasService {
     }
 
     private String translateContigRefseqToInsdc(String refseq) {
-        String url = contigAliasUrl + CONTIG_ALIAS_CHROMOSOMES_REFSEQ_ENDPOINT + refseq;
+        String url = UriComponentsBuilder.fromHttpUrl(contigAliasUrl)
+                .path(CONTIG_ALIAS_CHROMOSOMES_REFSEQ_ENDPOINT + "{refseq}")
+                .buildAndExpand(refseq)
+                .toUriString();
         ContigAliasResponse contigAliasResponse = restTemplate.getForObject(url, ContigAliasResponse.class);
         if (contigAliasResponse == null || contigAliasResponse.getEmbedded() == null) {
             return "";
@@ -195,8 +203,12 @@ public class ContigAliasService {
     }
 
     private String translateContigNameToInsdc(String contigName, String assembly, ContigNamingConvention contigNamingConvention) {
-        String url = contigAliasUrl + CONTIG_ALIAS_CHROMOSOMES_NAME_ENDPOINT + contigName
-                + "?accession=" + assembly + "&name=" + getNameParam(contigNamingConvention);
+        String url = UriComponentsBuilder.fromHttpUrl(contigAliasUrl)
+                .path(CONTIG_ALIAS_CHROMOSOMES_NAME_ENDPOINT + "{name}")
+                .queryParam("accession", assembly)
+                .queryParam("name", getNameParam(contigNamingConvention))
+                .buildAndExpand(contigName)
+                .toUriString();
         ContigAliasResponse contigAliasResponse = restTemplate.getForObject(url, ContigAliasResponse.class);
         if (contigAliasResponse == null || contigAliasResponse.getEmbedded() == null) {
             return "";
@@ -205,14 +217,15 @@ public class ContigAliasService {
     }
 
     public List<ContigAliasChromosome> searchChromosomeByName(String contigName, String assembly, ContigNamingConvention contigNamingConvention) {
-        String url = contigAliasUrl + CONTIG_ALIAS_CHROMOSOMES_SEARCH_ENDPOINT + contigName;
-        if ((assembly != null && !assembly.isEmpty()) && contigNamingConvention != null) {
-            url += "?assemblyAccession=" + assembly + "&namingConvention=" + getNameParam(contigNamingConvention);
-        } else if (assembly != null && !assembly.isEmpty()) {
-            url += "?assemblyAccession=" + assembly;
-        } else if (contigNamingConvention != null) {
-            url += "?namingConvention=" + getNameParam(contigNamingConvention);
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(contigAliasUrl)
+                .path(CONTIG_ALIAS_CHROMOSOMES_SEARCH_ENDPOINT + "{name}");
+        if (assembly != null && !assembly.isEmpty()) {
+            builder.queryParam("assemblyAccession", assembly);
         }
+        if (contigNamingConvention != null) {
+            builder.queryParam("namingConvention", getNameParam(contigNamingConvention));
+        }
+        String url = builder.buildAndExpand(contigName).toUriString();
 
         ContigAliasResponse contigAliasResponse = restTemplate.getForObject(url, ContigAliasResponse.class);
         if (contigAliasResponse == null || contigAliasResponse.getEmbedded() == null ||

--- a/eva-server/src/main/resources/application.properties
+++ b/eva-server/src/main/resources/application.properties
@@ -34,7 +34,7 @@ db.collection-names.annotations=|eva.mongo.collections.annotations|
 contig-alias.url=|contig-alias.url|
 
 management.endpoints.web.exposure.include=info,health
-management.info.git.mode=full
+management.info.git.mode=simple
 
 spring.jmx.default-domain=eva.ebi.ac.uk.|timestamp|
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>9.4.1212</version>
+                <version>42.7.4</version>
             </dependency>
             <dependency>
                 <groupId>asm</groupId>
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.193</version>
+                <version>2.2.224</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Fix 1: Rate limiter bypass (RateLimiterAspect.java)
The rate limiter used the X-Forwarded-For HTTP header as the per-IP bucket key. Any client could rotate this header on every request to create unlimited fresh buckets, bypassing the 5 req/sec cap entirely. The fix removes the header trust and uses the TCP-level remoteAddr instead, which a client cannot spoof.

Fix 2: HTTP parameter injection (ContigAliasService.java)
Chromosome names and assembly values were concatenated directly into URLs sent to the internal contig-alias service, without encoding. A crafted regionId containing ? or # characters could inject extra query parameters into those internal requests. The fix replaces all four string-concatenation URL builds with UriComponentsBuilder, which percent-encodes all user-supplied path segments and query values automatically.

Fix 3: Plaintext password in memory (SecurityConfiguration.java)
The {noop} Spring Security prefix meant the admin password for the count-stats write API was stored and compared as plaintext in JVM heap memory. A heap dump would expose it immediately. The fix registers a BCryptPasswordEncoder  bean and hashes the password at startup, so only the hash lives in memory.

Fix 4: Git metadata exposure (4 × application.properties)
 management.info.git.mode=full caused the /actuator/info endpoint to publish the full commit SHA, commit message, and timestamp — enough for an attacker to precisely identify the deployed version and match it against known CVEs. Changed to simple, which only exposes the abbreviated commit hash and branch name.

Dep bump: PostgreSQL JDBC (pom.xml)
Driver 9.4.1212 (2017) was affected by several CVEs including SQL injection via column names (CVE-2022-31197) and XXE (CVE-2020-13692). Updated to 42.7.4, the current stable release, which is a drop-in replacement for PostgreSQL 11.

Dep bump: H2 (pom.xml, test scope)
H2 1.4.193 (2016) carried CVE-2021-42392 (RCE via JNDI in the H2 console) and CVE-2022-45868. Although test-scoped, it could be exploited in developer and CI environments. Updated to 2.2.224.