### PR TITLE
EVA-4228 - Update gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ stages:
 
 variables:
     DOCKER_REGISTRY: dockerhub.ebi.ac.uk
+    DOCKER_IMAGE: $DOCKER_REGISTRY/ebivariation/eva-ws
     K8S_REPO_URL: https://github.com/EBIvariation/eva-k8s.git
     MAVEN_SETTINGS: maven-settings.xml
     URL_MAVEN_SETTINGS: https://api.github.com/repos/EBIvariation/configuration/contents/eva-maven-settings.xml
@@ -82,8 +83,10 @@ test:
         - curl -u $GITHUB_USER:$GITHUB_TOKEN -H "Accept:$MEDIA_TYPE" $KUBECONFIG_FILE > ~/.kube/config
         - chmod 600 ~/.kube/config
     script:
-       # Create/update the image pull secret in the target namespace from DOCKER_AUTH_CONFIG. It only updates if DOCKER_AUTH_CONFIG changes
-       - kubectl create secret generic regcred --type=kubernetes.io/dockerconfigjson --from-literal=.dockerconfigjson="$DOCKER_AUTH_CONFIG" -n $K8S_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+        # Create the target namespace if it doesn't already exist
+        - kubectl apply -f $K8S_MANIFEST_PATH/namespace.yaml
+        # Create/update the image pull secret in the target namespace from DOCKER_AUTH_CONFIG. It only updates if DOCKER_AUTH_CONFIG changes
+        - kubectl create secret generic regcred --type=kubernetes.io/dockerconfigjson --from-literal=.dockerconfigjson="$DOCKER_AUTH_CONFIG" -n $K8S_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
         - source $HOME/.venv/bin/activate
         # Download Maven settings from private repository
         - curl -u $GITHUB_USER:$GITHUB_TOKEN -H "Accept:$MEDIA_TYPE" $URL_MAVEN_SETTINGS > maven-settings.xml
@@ -117,7 +120,6 @@ build:docker:eva-server:dev:
     extends: .build_docker
     variables:
         DOCKERFILE_PATH: eva-server/Dockerfile
-        DOCKER_IMAGE: $DOCKER_REGISTRY/ebivariation/eva-server
         IMAGE_TAG: eva-server-dev-$CI_COMMIT_SHORT_SHA
         IMAGE_LATEST: dev-latest
     only:
@@ -170,7 +172,6 @@ build:docker:eva-release:dev:
     extends: .build_docker
     variables:
         DOCKERFILE_PATH: eva-release/Dockerfile
-        DOCKER_IMAGE: $DOCKER_REGISTRY/ebivariation/eva-release
         IMAGE_TAG: eva-release-dev-$CI_COMMIT_SHORT_SHA
         IMAGE_LATEST: dev-latest
     only:
@@ -223,7 +224,6 @@ build:docker:count-stats:dev:
     extends: .build_docker
     variables:
         DOCKERFILE_PATH: count-stats/Dockerfile
-        DOCKER_IMAGE: $DOCKER_REGISTRY/ebivariation/count-stats
         IMAGE_TAG: count-stat-dev-$CI_COMMIT_SHORT_SHA
         IMAGE_LATEST: dev-latest
     only:
@@ -277,28 +277,8 @@ build:docker:dgva-server:dev:
     extends: .build_docker
     variables:
         DOCKERFILE_PATH: dgva-server/Dockerfile
-        DOCKER_IMAGE: $DOCKER_REGISTRY/ebivariation/dgva-server
         IMAGE_TAG: dgva-server-dev-$CI_COMMIT_SHORT_SHA
         IMAGE_LATEST: dev-latest
-    only:
-        - master
-        - java21
-
-deploy:dgva-server:dev:
-    extends: .update_and_deploy
-    needs:
-        - build:docker:dgva-server:dev
-    variables:
-        SERVICE_NAME: dgva-server
-        PROPERTY_SET: dgva-server
-        IMAGE_TAG: dgva-server-dev-$CI_COMMIT_SHORT_SHA
-        ENV: development
-        MAVEN_PROFILE: development
-        K8S_MANIFEST_PATH: k8s-manifests/dgva-server/overlays/dev
-        K8S_NAMESPACE: dgva-server-dev
-        KUBECONFIG_FILE: $KUBECONFIG_FILE_DEV
-    environment:
-        name: development
     only:
         - master
         - java21

--- a/count-stats/src/main/resources/application.properties
+++ b/count-stats/src/main/resources/application.properties
@@ -6,6 +6,13 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 #controller.auth.admin.username=|eva.count-stats.username|
 #controller.auth.admin.password=|eva.count-stats.password|
 
+# HikariCP connection pool settings
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.idle-timeout=300000
+spring.datasource.hikari.max-lifetime=1800000
+
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 
 management.metrics.binders.jvm.enabled=false

--- a/dgva-server/src/main/resources/application.properties
+++ b/dgva-server/src/main/resources/application.properties
@@ -6,6 +6,13 @@
 spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
 spring.datasource.type=oracle.jdbc.pool.OracleDataSource
 
+# HikariCP connection pool settings
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.idle-timeout=300000
+spring.datasource.hikari.max-lifetime=1800000
+
 spring.jpa.database-platform=org.hibernate.dialect.OracleDialect
 spring.jpa.hibernate.ddl-auto = none
 

--- a/eva-release/Dockerfile
+++ b/eva-release/Dockerfile
@@ -35,7 +35,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:8080/eva/webservices/release/health || exit 1
+    CMD curl -f http://localhost:8080/eva/webservices/release/actuator/health || exit 1
 
 # JVM options for containerized environments
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC"

--- a/eva-release/src/main/resources/application.properties
+++ b/eva-release/src/main/resources/application.properties
@@ -3,6 +3,13 @@ spring.datasource.url=|eva.evapro.jdbc.url|?currentSchema=|eva.evapro.eva-stats.
 spring.datasource.username=|eva.evapro.user|
 spring.datasource.password=|eva.evapro.password|
 
+# HikariCP connection pool settings
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.idle-timeout=300000
+spring.datasource.hikari.max-lifetime=1800000
+
 # Make the model read-only and prevent any modification
 spring.jpa.generate-ddl=false
 # Disable automatic schema generation

--- a/eva-server/src/main/resources/application.properties
+++ b/eva-server/src/main/resources/application.properties
@@ -8,6 +8,13 @@
 # EVAPRO JNDI configuration
 #spring.datasource.jndi-name =  java:/comp/env/jdbc/|eva.evapro.datasource|
 
+# HikariCP connection pool settings
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.idle-timeout=300000
+spring.datasource.hikari.max-lifetime=1800000
+
 #Avoid hibernate ddl schema generation/update or validation
 spring.jpa.hibernate.ddl-auto = none
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
- Update Gitlab to make it work even when the first time the deployment is done
- Remove DGVA-dev because there are no connection to the ORACLE database
 - Limit the number of connection to postgreSQL to avoid overwhelming the database. 
   - Min 4 services * 3 pods * 1 connection = 12
   - Min 4 services * 3 pods * 5 connections = 60